### PR TITLE
feat(skills): add remocn agent skill for component discovery and usage

### DIFF
--- a/.agents/skills/remocn/SKILL.md
+++ b/.agents/skills/remocn/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: remocn
+description: >
+  Build Remotion videos with remocn — a shadcn registry of 65+ copy-paste animation components.
+  Use when composing video scenes, adding text animations, transitions, backgrounds, UI blocks,
+  or full compositions in a Remotion project. Triggers include "remocn", "video component",
+  "add animation", "text reveal", "scene transition", "product demo video", "remotion component",
+  "blur reveal", "typewriter", "terminal simulator", "glass code block", or any Remotion video
+  composition task. Even if the user doesn't mention remocn, activate when they need polished
+  video primitives for Remotion.
+---
+
+# remocn
+
+Copy-paste animation components for Remotion videos. Components install via `npx shadcn` and land
+in `components/remocn/` — you own the code.
+
+## Installation
+
+Prerequisites: a Remotion project (`npx create-video@latest`).
+
+```bash
+# Add any component
+npx shadcn@latest add https://remocn.dev/r/blur-reveal.json
+
+# Component lands at components/remocn/blur-reveal.tsx
+```
+
+The registry URL pattern is `https://remocn.dev/r/<component-name>.json`.
+
+## Component Categories
+
+Choose components by what you're building. Read `references/components.md` for the full catalog
+with props, descriptions, and implementation notes.
+
+### Text Animations
+
+Reveal, replace, and emphasize text.
+
+| Component | Use case |
+|---|---|
+| `blur-reveal` | Fade in from heavy blur to sharp focus |
+| `typewriter` | Character-by-character typing with blinking cursor |
+| `inline-highlight` | Animate one word's color in a sentence |
+| `text-fade-replace` | Cross-fade between two strings without layout shift |
+| `strikethrough-replace` | Strike old text, reveal new text |
+| `staggered-fade-up` | Words fade+slide up in a wave |
+| `masked-slide-reveal` | Words slide up out of a clipped mask |
+| `tracking-in` | Letter-spacing collapses with spring bounce |
+| `shimmer-sweep` | Light sweep across text via `background-clip: text` |
+| `marker-highlight` | Marker block draws behind a phrase |
+| `slot-machine-roll` | Vertical reel scroll between values |
+| `matrix-decode` | Random characters resolve into target text |
+| `rgb-glitch-text` | RGB-offset jitter glitch effect |
+| `infinite-marquee` | Seamless looping horizontal text strip |
+
+### Backgrounds & Primitives
+
+Animated foundations and micro-interactions.
+
+| Component | Use case |
+|---|---|
+| `mesh-gradient-bg` | Drifting amorphous gradient blobs |
+| `dynamic-grid` | Subtle moving grid/dot background |
+| `spring-pop-in` | Elastic scale-in wrapper for any element |
+| `simulated-cursor` | Mouse cursor moving between waypoints with click feedback |
+| `pulsing-indicator` | Continuous pulsing dot for loading/live states |
+
+### Transitions & Wipes
+
+Swap between scenes.
+
+| Component | Use case |
+|---|---|
+| `directional-wipe` | Push one scene out while sliding another in |
+| `frosted-glass-wipe` | Sliding frosted glass pane between scenes |
+| `kinetic-type-mask` | Giant text as a window into the next scene |
+| `spatial-push` | New scene physically presses old one back |
+| `grid-pixelate-wipe` | Dissolve through a grid of mask cells |
+| `chromatic-aberration-wipe` | Ultra-fast slide with RGB glitch at peak |
+| `zoom-through-transition` | Aggressive scale into element center |
+| `swipe-transition-wipe` | Side-by-side flick with parallax + dimming |
+
+### UI Blocks
+
+Interface simulations for product demos.
+
+| Component | Use case |
+|---|---|
+| `glass-code-block` | Frosted-glass code editor with syntax highlighting |
+| `terminal-simulator` | CLI window with chunked line output and auto-scroll |
+| `browser-flow` | Safari/Chrome simulation with URL bar and page render |
+| `toast-notification` | System toast that pops in, holds, slides out |
+| `animated-line-chart` | SVG line chart that draws on progressively |
+| `animated-bar-chart` | Bars spring up in a staggered cascade |
+| `code-diff-wipe` | Before/after code reveal via clip-path |
+| `code-accordion` | Collapse a range of code lines with a placeholder |
+| `device-mockup-zoom` | Pull back from UI to reveal device frame |
+| `morphing-modal` | Card lifts off grid and blooms into full-screen modal |
+| `spotlight-card` | Radial spotlight follows cursor over card border |
+| `progress-steps` | Multi-step pipeline with sequential activation |
+| `drag-and-drop-flow` | Simulated file drag into dropzone |
+| `bounding-box-selector` | Figma-style selection rectangle |
+| `chat-to-preview-layout` | Two-column layout where chat shrinks, preview grows |
+| `staggered-bento-grid` | Cards cascade into bento grid |
+| `cursor-flow` | Realistic bezier-pathed mouse with click physics |
+| `data-flow-pipes` | Glowing packets travel along SVG bezier pipes |
+| `perspective-marquee` | 3D-tilted infinite marquee with depth blur |
+| `success-confetti` | Deterministic seeded confetti burst |
+| `pricing-tier-focus` | Focused tier rises while siblings dim |
+| `infinite-bento-pan` | Camera drifts across oversized bento grid |
+
+### Full Compositions
+
+Ready-to-use multi-scene sequences.
+
+| Component | Use case |
+|---|---|
+| `product-launch-trailer` | Logo → zoom-through → 3D bento → confetti version drop |
+| `hero-device-assemble` | Floating layers spring together into device mockup |
+| `changelog-bite` | Looping before/after diff card with frosted wipe |
+| `terminal-to-browser-deploy` | CLI deploy → blur → browser springs from URL |
+| `landing-code-showcase` | Split-screen: code types left, preview renders right |
+| `live-code-compilation` | Split-screen HMR-style code + live preview |
+| `dashboard-populate` | Empty dashboard cascades to life with animated data |
+| `pipeline-journey` | Kanban ticket arcs across columns with confetti |
+| `ecosystem-constellation` | Central logo orbited by integration satellites |
+| `ai-generation-canvas` | Prompt → header → skeleton → populated cards |
+| `visual-docs-snippet` | Cursor clicks button, bounding box + tooltip explain it |
+| `ai-generate-overlay` | Source blurs under shimmer grid, new image fades in |
+| `tool-menu-slide-in` | Glass tool palette slides up with staggered icons |
+| `image-expand-to-fullscreen` | Image lifts from feed post into fullscreen editor |
+| `brush-stroke-simulator` | Finger brushes across image revealing pixelated layer |
+| `volumetric-rays` | Cinematic god rays through text/logo silhouette |
+
+## Component Patterns
+
+All remocn components follow these conventions:
+
+### Props
+
+- Every component exports a named `Props` interface (e.g., `BlurRevealProps`)
+- `speed?: number` — global time multiplier (default `1`), applied as `frame * speed`
+- `className?: string` — optional CSS class on root element
+- Category-specific defaults: text components have `fontSize`, `color`, `fontWeight`; transitions have `transitionStart`, `transitionDuration`
+
+### Animation API
+
+Components use Remotion's core animation primitives:
+
+```tsx
+import { interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
+
+// Linear interpolation
+const opacity = interpolate(frame, [0, 30], [0, 1], { extrapolateRight: "clamp" });
+
+// Spring physics
+const scale = spring({ fps, frame, config: { damping: 12, mass: 1, stiffness: 100 } });
+
+// Deterministic randomness (NEVER use Math.random())
+import { random } from "@remotion/random";
+const jitter = random(`seed-${frame}`);
+```
+
+### Composition structure
+
+```tsx
+import { Composition, Sequence, Series } from "remotion";
+
+// Sequence for timed sub-scenes
+<Sequence from={30} durationInFrames={60}>
+  <BlurReveal text="Hello" />
+</Sequence>
+
+// Series for back-to-back items
+<Series>
+  <Series.Sequence durationInFrames={60}><SceneA /></Series.Sequence>
+  <Series.Sequence durationInFrames={60}><SceneB /></Series.Sequence>
+</Series>
+```
+
+### Transitions wrap two scenes
+
+```tsx
+<FrostedGlassWipe
+  from={<SceneA />}
+  to={<SceneB />}
+  transitionDuration={30}
+/>
+```
+
+## Gotchas
+
+- **Never use `Math.random()`** — renders are multi-pass. Use `random(seed)` from `@remotion/random`
+- **Never use `setInterval`/`setTimeout`** — derive everything from `useCurrentFrame()`
+- **Animate `transform` not `top`/`left`** — avoids layout reflow during frame rendering
+- **Fonts must be loaded before render** — use `@remotion/google-fonts` or `@remotion/fonts`
+- **Static files go in `public/`** — load via `staticFile('cursor.svg')`, not imports
+- **Cursor blink must be deterministic** — `Math.floor(frame / 15) % 2 === 0`, not intervals
+- **Terminal scroll is instant** — use step-function `translateY`, never spring/ease the scroll
+- **`overflow: hidden` on split layouts** — prevents content breakage during width animations
+- **`extrapolateRight: "clamp"` by default** — prevents values overshooting their target range
+
+## Composing a Video
+
+Typical workflow for a product demo:
+
+1. **Pick a background**: `mesh-gradient-bg` or `dynamic-grid`
+2. **Add a title reveal**: `blur-reveal`, `staggered-fade-up`, or `tracking-in`
+3. **Show the product**: `browser-flow`, `terminal-simulator`, or `glass-code-block`
+4. **Transition between scenes**: `frosted-glass-wipe`, `spatial-push`, or `directional-wipe`
+5. **End with impact**: `success-confetti`, `product-launch-trailer`, or `pricing-tier-focus`
+
+Or use a full composition like `product-launch-trailer` and customize its sub-scenes.
+
+## Reference
+
+For the complete component catalog with detailed implementation notes and props:
+
+→ `references/components.md`

--- a/.agents/skills/remocn/references/components.md
+++ b/.agents/skills/remocn/references/components.md
@@ -1,0 +1,535 @@
+# remocn Component Reference
+
+Complete props and usage for all 65 components. Install any component:
+
+```bash
+npx shadcn@latest add https://remocn.dev/r/<name>.json
+```
+
+---
+
+## Text Animations
+
+### blur-reveal
+
+Text fades from heavy blur to sharp focus.
+
+```tsx
+<BlurReveal text="Hello World" blur={10} fontSize={48} color="#171717" fontWeight={600} speed={1} />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `text` | `string` | required | Text to reveal |
+| `blur` | `number` | `10` | Initial blur radius in px |
+| `fontSize` | `number` | `48` | Font size |
+| `color` | `string` | `"#171717"` | Text color |
+| `fontWeight` | `number` | `600` | Font weight |
+| `speed` | `number` | `1` | Time multiplier |
+
+### typewriter
+
+Character-by-character typing with deterministic blinking cursor.
+
+```tsx
+<Typewriter text="npm install remocn" charsPerSecond={20} cursor={true} cursorColor="#22c55e" />
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `text` | `string` | required |
+| `cursor` | `boolean` | `true` |
+| `charsPerSecond` | `number` | `20` |
+| `cursorColor` | `string` | `"#fafafa"` |
+| `fontSize` | `number` | `48` |
+| `color` | `string` | `"#171717"` |
+
+### inline-highlight
+
+Animate one word's color in a sentence using `interpolateColors`.
+
+```tsx
+<InlineHighlight text="Build videos fast" highlightWord="fast" toColor="#0ea5e9" />
+```
+
+### text-fade-replace
+
+Cross-fade between two strings without layout shift. Uses `position: absolute` layering.
+
+```tsx
+<TextFadeReplace from="Loading..." to="Complete!" />
+```
+
+### strikethrough-replace
+
+Draws strike line across old text, then reveals new text.
+
+```tsx
+<StrikethroughReplace from="$99/mo" to="$49/mo" />
+```
+
+### staggered-fade-up
+
+Words fade in and slide up one after another.
+
+```tsx
+<StaggeredFadeUp text="Build amazing videos" staggerDelay={5} distance={20} fontSize={64} />
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `text` | `string` | required |
+| `staggerDelay` | `number` | `5` |
+| `distance` | `number` | `20` |
+
+### masked-slide-reveal
+
+Words slide up from behind a clipped mask (`overflow: hidden` container with fixed `line-height`).
+
+```tsx
+<MaskedSlideReveal text="Reveal from below" />
+```
+
+### tracking-in
+
+Letter-spacing collapses from wide to normal with spring bounce + blur clear.
+
+```tsx
+<TrackingIn text="LAUNCH" />
+```
+
+### shimmer-sweep
+
+Light sweep across muted text using `background-clip: text` and `background-position` animation.
+
+```tsx
+<ShimmerSweep text="AI-powered generation" />
+```
+
+### marker-highlight
+
+Colored marker block draws behind a phrase. Uses `::after` or absolute div with `z-index: -1`.
+
+```tsx
+<MarkerHighlight text="Important" highlightColor="#facc15" />
+```
+
+### slot-machine-roll
+
+Vertical reel scrolls characters from one value to another. `overflow: hidden` container.
+
+```tsx
+<SlotMachineRoll from="$99" to="$199" />
+```
+
+### matrix-decode
+
+Random characters resolve left-to-right. Uses `random(seed)` from `@remotion/random`.
+
+```tsx
+<MatrixDecode text="ENCRYPTED" />
+```
+
+### rgb-glitch-text
+
+Three RGB-offset text copies jitter briefly. Three `position: absolute` layers offset 2-5px.
+
+```tsx
+<RGBGlitchText text="GLITCH" />
+```
+
+### infinite-marquee
+
+Seamless looping horizontal strip. Duplicated content with `translateX` cycling.
+
+```tsx
+<InfiniteMarquee text="REMOCN · REMOTION · REACT ·" />
+```
+
+---
+
+## Backgrounds & Primitives
+
+### mesh-gradient-bg
+
+Drifting gradient blobs. Accepts color array.
+
+```tsx
+<MeshGradientBg colors={["#0ea5e9", "#9333ea", "#f97316"]} blur={120} />
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `colors` | `string[]` | blue/purple/orange |
+| `blur` | `number` | `120` |
+| `background` | `string` | `"#050505"` |
+
+### dynamic-grid
+
+Moving grid/dot background via CSS `linear-gradient` or SVG `<pattern>`.
+
+```tsx
+<DynamicGrid cellSize={40} />
+```
+
+### spring-pop-in
+
+Elastic scale-in wrapper. Wraps any children.
+
+```tsx
+<SpringPopIn damping={12} mass={1} stiffness={100} delayInFrames={0}>
+  <MyComponent />
+</SpringPopIn>
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` | default demo card |
+| `damping` | `number` | `12` |
+| `mass` | `number` | `1` |
+| `stiffness` | `number` | `100` |
+| `delayInFrames` | `number` | `0` |
+
+### simulated-cursor
+
+Mouse cursor following waypoints with click ripple.
+
+```tsx
+<SimulatedCursor waypoints={[{ x: 100, y: 200 }, { x: 500, y: 300, click: true }]} />
+```
+
+### pulsing-indicator
+
+Continuous pulse using `Math.sin(frame / speed)` mapped to scale 0.9–1.1.
+
+```tsx
+<PulsingIndicator />
+```
+
+---
+
+## Transitions & Wipes
+
+All transitions accept `from` and `to` as `ReactNode` children (the two scenes).
+
+### frosted-glass-wipe
+
+Sliding frosted glass pane reveals new scene. Three layers: Scene A, Scene B, glass panel.
+
+```tsx
+<FrostedGlassWipe
+  from={<SceneA />}
+  to={<SceneB />}
+  transitionDuration={30}
+  glassBlur={24}
+/>
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `from` | `ReactNode` | blue panel |
+| `to` | `ReactNode` | purple panel |
+| `transitionStart` | `number` | 40% of duration |
+| `transitionDuration` | `number` | `30` |
+| `glassBlur` | `number` | `24` |
+
+### chromatic-aberration-wipe
+
+Ultra-fast slide with RGB glitch at peak velocity.
+
+```tsx
+<ChromaticAberrationWipe from={<A />} to={<B />} aberrationOffset={8} />
+```
+
+### directional-wipe
+
+Classic push/slide transition. Uses `transform: translateX/Y` (never `left`/`top`).
+
+```tsx
+<DirectionalWipe from={<A />} to={<B />} direction="left" />
+```
+
+### kinetic-type-mask
+
+Giant text masks the next scene. Text scales exponentially via `transform: scale(100)`.
+
+```tsx
+<KineticTypeMask text="NEXT" from={<A />} to={<B />} />
+```
+
+### spatial-push
+
+New scene physically presses old one back with 3D perspective.
+
+```tsx
+<SpatialPush from={<A />} to={<B />} />
+```
+
+### grid-pixelate-wipe
+
+Dissolve through deterministic grid of mask cells.
+
+```tsx
+<GridPixelateWipe from={<A />} to={<B />} columns={12} rows={8} />
+```
+
+### zoom-through-transition
+
+Aggressive scale into element center with exponential easing.
+
+```tsx
+<ZoomThroughTransition from={<A />} to={<B />} />
+```
+
+### swipe-transition-wipe
+
+Side-by-side flick with parallax background and darkening outgoing layer.
+
+```tsx
+<SwipeTransitionWipe from={<A />} to={<B />} />
+```
+
+---
+
+## UI Blocks
+
+### glass-code-block
+
+Premium frosted-glass code window with regex tokenizer and staggered line reveal.
+
+```tsx
+<GlassCodeBlock
+  code={`const x = 42;\nconsole.log(x);`}
+  title="app.tsx"
+  fontSize={16}
+  staggerFrames={3}
+/>
+```
+
+| Prop | Type | Default |
+|---|---|---|
+| `code` | `string` | sample code |
+| `title` | `string` | `"app.tsx"` |
+| `fontSize` | `number` | `16` |
+| `staggerFrames` | `number` | `3` |
+| `showTrafficLights` | `boolean` | `true` |
+| `glassColor` | `string` | semi-transparent |
+
+### terminal-simulator
+
+CLI window with chunked line output and step-function scroll.
+
+```tsx
+<TerminalSimulator
+  lines={[
+    { text: "npm run build", type: "command", delay: 0 },
+    { text: "Compiling...", type: "log", delay: 12 },
+    { text: "Build complete", type: "success", delay: 14 },
+  ]}
+  prompt="$"
+  title="~/project"
+/>
+```
+
+Line types: `"command"` | `"log"` | `"success"` | `"error"`. Lines ending in `"..."` auto-pause for 18 frames.
+
+### browser-flow
+
+Full Safari/Chrome simulation: typed URL, progress bar, page render, scroll, cursor click.
+
+```tsx
+<BrowserFlow url="https://remocn.dev" />
+```
+
+### animated-line-chart
+
+SVG line chart that draws via `stroke-dashoffset` animation with optional leading dot.
+
+```tsx
+<AnimatedLineChart data={[10, 40, 30, 80, 60, 90]} strokeColor="#0ea5e9" />
+```
+
+### animated-bar-chart
+
+Bars spring up from baseline in staggered cascade via `scaleY` with `transform-origin: bottom`.
+
+```tsx
+<AnimatedBarChart data={[40, 70, 30, 90, 55]} />
+```
+
+### cursor-flow
+
+Realistic bezier-pathed mouse movement with click physics (scale dip on click target).
+
+```tsx
+<CursorFlow
+  waypoints={[
+    { x: 200, y: 300, hold: 10 },
+    { x: 600, y: 400, click: true, label: "Submit" },
+  ]}
+  segmentDuration={30}
+/>
+```
+
+### data-flow-pipes
+
+Glowing packets on SVG bezier pipes using `stroke-dasharray` + `stroke-dashoffset` animation.
+
+```tsx
+<DataFlowPipes nodes={[...]} />
+```
+
+### morphing-modal
+
+Card lifts from grid and blooms to full-screen. Heavy spring on 5 properties simultaneously.
+
+```tsx
+<MorphingModal />
+```
+
+### code-diff-wipe
+
+Before/after code via `clip-path: inset()` animation.
+
+```tsx
+<CodeDiffWipe before={oldCode} after={newCode} />
+```
+
+### code-accordion
+
+Collapses a line range with spring height animation. Placeholder shows "N lines collapsed".
+
+```tsx
+<CodeAccordion code={longCode} collapseFrom={10} collapseTo={45} />
+```
+
+### toast-notification
+
+Positioned toast with spring entry and interpolated exit.
+
+```tsx
+<ToastNotification message="Deployed!" type="success" />
+```
+
+### device-mockup-zoom
+
+Pull back from UI to reveal it inside device frame loaded via `staticFile()`.
+
+```tsx
+<DeviceMockupZoom device="laptop" />
+```
+
+### spotlight-card
+
+Radial gradient follows cursor coordinates over card's microborder.
+
+```tsx
+<SpotlightCard />
+```
+
+### perspective-marquee
+
+3D-tilted infinite marquee with depth-of-field blur on distant items.
+
+```tsx
+<PerspectiveMarquee items={["Logo1", "Logo2", "Logo3"]} />
+```
+
+### success-confetti
+
+Deterministic confetti using `random(seed)` from `@remotion/random`. Canvas-rendered particles.
+
+```tsx
+<SuccessConfetti headline="Shipped!" />
+```
+
+---
+
+## Full Compositions
+
+### product-launch-trailer
+
+Multi-scene cinematic sequence: pulsing logo → zoom-through → 3D bento fly-over → confetti.
+
+```tsx
+<ProductLaunchTrailer
+  logoLabel="⚡"
+  productName="My App"
+  versionLabel="v1.0"
+  accentPeach="#fbbf24"
+  accentLavender="#a78bfa"
+  accentMint="#34d399"
+/>
+```
+
+### dashboard-populate
+
+Empty dashboard cascades to life: KPI count-ups, bar bounces, line traces, donut fill.
+
+```tsx
+<DashboardPopulate accentColor="#0ea5e9" kpiTarget={12847} />
+```
+
+### terminal-to-browser-deploy
+
+CLI deploy completes → terminal blurs → browser window springs from deploy URL.
+
+```tsx
+<TerminalToBrowserDeploy />
+```
+
+### landing-code-showcase
+
+Split-screen: code types on left, preview renders on right with sparks.
+
+```tsx
+<LandingCodeShowcase />
+```
+
+### changelog-bite
+
+Looping square card: before/after diff with frosted glass wipe and pulsing "New" pill.
+
+```tsx
+<ChangelogBite />
+```
+
+### hero-device-assemble
+
+Floating layers spring together into laptop/phone mockup, screen wakes with shimmer.
+
+```tsx
+<HeroDeviceAssemble />
+```
+
+### pipeline-journey
+
+Kanban ticket arcs across columns with landing effects and final confetti.
+
+```tsx
+<PipelineJourney />
+```
+
+### ecosystem-constellation
+
+Central logo orbited by integration satellites with pulsing data lines.
+
+```tsx
+<EcosystemConstellation />
+```
+
+### ai-generation-canvas
+
+Prompt input → header morph → skeleton dashboard → populated cards.
+
+```tsx
+<AIGenerationCanvas />
+```
+
+### visual-docs-snippet
+
+Tutorial flow: cursor arcs to button, clicks, bounding box + tooltip explain result.
+
+```tsx
+<VisualDocsSnippet />
+```


### PR DESCRIPTION
## What

Adds an OpenClaw-format agent skill (`.agents/skills/remocn/`) that teaches AI coding agents how to discover and use remocn components in Remotion projects. Installable via `npx skills add`.

## Why

remocn has 65+ components and agents need structured knowledge to pick the right one, use correct props, and avoid Remotion-specific pitfalls. The existing `remotion-best-practices` skill covers Remotion fundamentals — this skill covers **remocn itself**: the component catalog, installation, composition patterns, and gotchas.

## How

Two files following the [OpenClaw Agent Skills](https://agentskills.io) standard:

- **`SKILL.md`** (220 lines) — loaded when an agent activates the skill:
  - Installation instructions (`npx shadcn@latest add`)
  - Component catalog organized into 5 categories (text, backgrounds, transitions, UI blocks, compositions) with tables
  - Component patterns (props conventions, animation API, Sequence/Series structure)
  - Gotchas (no `Math.random()`, no `setInterval`, animate `transform` not `top`/`left`, deterministic cursor blink, step-function terminal scroll, etc.)
  - Composing a video workflow

- **`references/components.md`** (535 lines) — loaded on demand for detailed lookups:
  - Full props tables with types and defaults for every component
  - Usage code snippets
  - Implementation notes

### Installation

Once merged, anyone can add this skill to their agent:

```bash
npx skills add kapishdima/remocn@remocn
```

## Testing

- Validated frontmatter format (name, description with trigger keywords)
- SKILL.md is 220 lines (under 500-line limit)
- All 65 registry components are covered
- Skill follows progressive disclosure: catalog tables in SKILL.md, full props in references/