### PR TITLE
feat: add llms.txt, llms-full.txt, and raw .md docs routes for AI agents

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,15 @@
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/source";
+
+export const revalidate = false;
+
+// llms-full.txt — every doc page concatenated as Markdown, for LLMs that want
+// the entire corpus in one request.
+export async function GET() {
+  const pages = source.getPages();
+  const docs = await Promise.all(pages.map((page) => getLLMText(page)));
+
+  return new Response(docs.join("\n\n---\n\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/app/llms.md/[[...slug]]/route.ts
+++ b/app/llms.md/[[...slug]]/route.ts
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/source";
+
+export const revalidate = false;
+
+// Serves the processed Markdown for a single doc page.
+// Reached via the `/docs/:path*.md` rewrite in next.config.ts, so a request to
+// `/docs/getting-started/introduction.md` returns raw Markdown for AI agents.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,44 @@
+import { SITE_URL } from "@/lib/get-llm-text";
+import { source } from "@/source";
+
+export const revalidate = false;
+
+// llms.txt — curated index of the docs for LLMs (https://llmstxt.org).
+// Each entry links to the page's raw Markdown (`*.md`) served by app/llms.md.
+export function GET() {
+  const scanned: string[] = [];
+
+  scanned.push("# remocn");
+  scanned.push(
+    "\n> shadcn registry of production-ready Remotion components — animations, transitions, backgrounds, and full scenes. Install with `npx shadcn add remocn/<component>`.",
+  );
+  scanned.push(
+    "\nDocs are also available as raw Markdown: append `.md` to any docs URL, or read [/llms-full.txt](" +
+      `${SITE_URL}/llms-full.txt) for the full corpus in a single file.`,
+  );
+
+  // Group pages by their top-level section (first slug segment).
+  const sections = new Map<string, ReturnType<typeof source.getPages>>();
+  for (const page of source.getPages()) {
+    const key = page.slugs[0] ?? "";
+    const bucket = sections.get(key) ?? [];
+    bucket.push(page);
+    sections.set(key, bucket);
+  }
+
+  for (const [key, pages] of sections) {
+    const heading = key
+      ? key.replace(/(^|-)([a-z])/g, (_, sep, c) => (sep ? " " : "") + c.toUpperCase())
+      : "Overview";
+    scanned.push(`\n## ${heading}`);
+    for (const page of pages) {
+      const data = page.data;
+      const desc = data.description ? `: ${data.description}` : "";
+      scanned.push(`- [${data.title}](${SITE_URL}${page.url}.md)${desc}`);
+    }
+  }
+
+  return new Response(scanned.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/lib/get-llm-text.ts
+++ b/lib/get-llm-text.ts
@@ -1,0 +1,28 @@
+import type { InferPageType } from "fumadocs-core/source";
+import type { source } from "@/source";
+
+export const SITE_URL = "https://remocn.dev";
+
+type DocPage = InferPageType<typeof source>;
+
+/**
+ * Render a single doc page as a self-contained Markdown document for LLMs.
+ * Uses the processed Markdown emitted by fumadocs-mdx (`includeProcessedMarkdown`
+ * in source.config.ts), prefixed with a title + source URL header.
+ */
+export async function getLLMText(page: DocPage): Promise<string> {
+  const data = page.data as typeof page.data & {
+    getText: (type: "raw" | "processed") => Promise<string>;
+  };
+  const processed = await data.getText("processed");
+
+  return [
+    `# ${data.title}`,
+    `URL: ${SITE_URL}${page.url}`,
+    data.description ? `\n${data.description}` : "",
+    "",
+    processed,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,10 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async rewrites() {
+    // Serve raw Markdown for AI agents: `/docs/<slug>.md` -> app/llms.md route.
+    return [{ source: "/docs/:path*.md", destination: "/llms.md/:path*" }];
+  },
   typescript: {
     // Type-check ломается из-за коллизии @types/mdx × @react-three/fiber
     // (см. mdx-components.tsx). Рантайм не затронут.


### PR DESCRIPTION
Expose Fumadocs
  content as plain Markdown for LLMs:
  - /llms.txt — curated index grouped by section, links to each page's .md
  - /llms-full.txt — full docs corpus in a single file
  - /docs/<slug>.md — per-page processed Markdown via app/llms.md route + next.config rewrite

  Uses fumadocs-mdx includeProcessedMarkdown (page.data.getText('processed')).