### PR TITLE
feat: registry drift guard (public/r vs registry/ sources)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "biome check",
     "format": "biome format --write",
     "registry:build": "shadcn build",
+    "registry:check": "shadcn build && git diff --quiet -- public/r || (echo 'public/r is out of sync with registry/ sources. Run: bun run registry:build and commit the result.' && exit 1)",
     "remotion:browser": "bun scripts/ensure-browser.mts",
     "bundle:remotion": "bun scripts/bundle-remotion.mts",
     "render:demos": "bun scripts/render-demos.mts",


### PR DESCRIPTION
Adds a `registry:check` script: rebuilds the registry via `shadcn build` and fails if `public/r` no longer matches the committed output, with a hint to run `bun run registry:build`.

This becomes a CI gate in plan 010.

Plan: `plans/008-registry-drift-guard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)