### PR TITLE
perf: in-view gating for landing page Remotion players

### DIFF
--- a/app/(home)/components/sections/bento-registry.tsx
+++ b/app/(home)/components/sections/bento-registry.tsx
@@ -85,7 +85,7 @@ function BentoCard({
   const entry = registry[name];
   const playerRef = useRef<PlayerRef>(null);
 
-  useAutoplay(playerRef, Boolean(entry));
+  const { containerRef } = useAutoplay(playerRef, Boolean(entry));
 
   const Composition = useMemo(() => {
     const Inner = entry?.Component;
@@ -119,6 +119,7 @@ function BentoCard({
       />
 
       <div
+        ref={containerRef}
         className={cn(
           "relative w-full overflow-hidden",
           featured

--- a/app/(home)/components/sections/interactive-code.tsx
+++ b/app/(home)/components/sections/interactive-code.tsx
@@ -256,7 +256,7 @@ export function InteractiveCode() {
   const entry = registry[COMPONENT];
   const playerRef = useRef<PlayerRef>(null);
 
-  useAutoplay(playerRef, Boolean(entry));
+  const { containerRef } = useAutoplay(playerRef, Boolean(entry));
 
   const [text, setText] = useState(TYPEWRITER_DEFAULTS.text);
   const [fontSize, setFontSize] = useState(TYPEWRITER_DEFAULTS.fontSize);
@@ -358,7 +358,7 @@ export function InteractiveCode() {
               transition={SPRING_SOFT}
               className="relative flex items-center justify-center overflow-hidden rounded-2xl bg-white shadow-2xl shadow-black/5 ring-1 ring-black/5 sm:rounded-3xl"
             >
-              <div className="w-full" style={{ aspectRatio }}>
+              <div ref={containerRef} className="w-full" style={{ aspectRatio }}>
                 {entry ? (
                   <Player
                     ref={playerRef}

--- a/app/(home)/components/sections/ui-registry.tsx
+++ b/app/(home)/components/sections/ui-registry.tsx
@@ -69,25 +69,27 @@ const PRIMITIVE_CHIPS = [
 
 function ScenePlayer({ entry }: { entry: SceneEntry | undefined }) {
   const ref = useRef<PlayerRef>(null);
-  useAutoplay(ref, Boolean(entry));
+  const { containerRef } = useAutoplay(ref, Boolean(entry));
 
   if (!entry) return null;
 
   return (
-    <Player
-      ref={ref}
-      component={entry.Component}
-      inputProps={{}}
-      durationInFrames={entry.durationInFrames}
-      fps={entry.fps}
-      compositionWidth={entry.width}
-      compositionHeight={entry.height}
-      style={{ width: "100%", height: "100%", pointerEvents: "none" }}
-      clickToPlay={false}
-      loop
-      initiallyMuted
-      acknowledgeRemotionLicense
-    />
+    <div ref={containerRef} style={{ width: "100%", height: "100%" }}>
+      <Player
+        ref={ref}
+        component={entry.Component}
+        inputProps={{}}
+        durationInFrames={entry.durationInFrames}
+        fps={entry.fps}
+        compositionWidth={entry.width}
+        compositionHeight={entry.height}
+        style={{ width: "100%", height: "100%", pointerEvents: "none" }}
+        clickToPlay={false}
+        loop
+        initiallyMuted
+        acknowledgeRemotionLicense
+      />
+    </div>
   );
 }
 

--- a/app/(home)/components/use-autoplay.ts
+++ b/app/(home)/components/use-autoplay.ts
@@ -1,15 +1,41 @@
 import type { PlayerRef } from "@remotion/player";
-import { type RefObject, useEffect } from "react";
+import { useIntersectionObserver } from "@uidotdev/usehooks";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
 
 export function useAutoplay(
   playerRef: RefObject<PlayerRef | null>,
   enabled = true,
-) {
+): { containerRef: (node: Element | null) => void } {
+  const [observerRef, entry] = useIntersectionObserver({
+    threshold: 0,
+    root: null,
+    rootMargin: "200px",
+  });
+
+  const attached = useRef(false);
+  const containerRef = useCallback(
+    (node: Element | null) => {
+      if (node) attached.current = true;
+      observerRef(node);
+    },
+    [observerRef],
+  );
+
   useEffect(() => {
     if (!enabled) return;
+
+    const visible = attached.current
+      ? Boolean(entry?.isIntersecting)
+      : true;
+
+    if (!visible) {
+      playerRef.current?.pause();
+      return;
+    }
+
     let raf = 0;
     let attempts = 0;
-    const MAX_ATTEMPTS = 120; // ~2s at 60fps, longer on a contended mount
+    const MAX_ATTEMPTS = 120;
     const tick = () => {
       const player = playerRef.current;
       if (player && !player.isPlaying()) player.play();
@@ -20,5 +46,7 @@ export function useAutoplay(
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [playerRef, enabled]);
+  }, [enabled, entry, playerRef]);
+
+  return { containerRef };
 }


### PR DESCRIPTION
Landing page Remotion players now only play while visible in the viewport (IntersectionObserver in `use-autoplay.ts`), instead of all ~13 running simultaneously.

Touched: `bento-registry.tsx`, `interactive-code.tsx`, `ui-registry.tsx`, `use-autoplay.ts`.

The existing autoplay workaround (mount paused, drive `play()` via PlayerRef with rAF retry) is preserved.

Plan: `plans/012-player-in-view-gating.md`

**Note:** plan 013 (lazy registry barrels) builds on this diff — merge/reject this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)