### PR TITLE
test: port 17 vitest suites to bun:test and add test script

### DIFF
--- a/app/api/render/__tests__/route.test.ts
+++ b/app/api/render/__tests__/route.test.ts
@@ -8,25 +8,30 @@
  * so no real renders, rate-buckets, or filesystem ops occur.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { JobState } from "@/lib/server/render-queue";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the route handlers.
 // ---------------------------------------------------------------------------
 
-vi.mock("server-only", () => ({}));
+const mockEnqueue = mock();
+const mockGetJob = mock();
+const mockCheckRate = mock();
 
-vi.mock("@/lib/server/render-queue", () => ({
-  enqueueRender: vi.fn(),
-  getJob: vi.fn(),
+mock.module("server-only", () => ({}));
+
+mock.module("@/lib/server/render-queue", () => ({
+  enqueueRender: mockEnqueue,
+  getJob: mockGetJob,
 }));
 
-vi.mock("@/lib/server/rate-limit", () => ({
-  checkRateLimit: vi.fn(),
+mock.module("@/lib/server/rate-limit", () => ({
+  checkRateLimit: mockCheckRate,
 }));
 
-vi.mock("@/lib/server/cleanup", () => ({
-  ensureCleanupSweep: vi.fn(),
+mock.module("@/lib/server/cleanup", () => ({
+  ensureCleanupSweep: mock(),
 }));
 
 // validate-input is NOT mocked: we use the real parser so the route's
@@ -36,19 +41,13 @@ vi.mock("@/lib/server/cleanup", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { POST } from "@/app/api/render/route";
-import { GET } from "@/app/api/render/[jobId]/route";
-import { enqueueRender } from "@/lib/server/render-queue";
-import { getJob } from "@/lib/server/render-queue";
-import { checkRateLimit } from "@/lib/server/rate-limit";
-import type { JobState } from "@/lib/server/render-queue";
-
-const mockEnqueue = vi.mocked(enqueueRender);
-const mockGetJob = vi.mocked(getJob);
-const mockCheckRate = vi.mocked(checkRateLimit);
+const { POST } = await import("@/app/api/render/route");
+const { GET } = await import("@/app/api/render/[jobId]/route");
 
 afterEach(() => {
-  vi.clearAllMocks();
+  mockEnqueue.mockClear();
+  mockGetJob.mockClear();
+  mockCheckRate.mockClear();
 });
 
 // ---------------------------------------------------------------------------

--- a/app/api/stargazers/__tests__/route.test.ts
+++ b/app/api/stargazers/__tests__/route.test.ts
@@ -6,30 +6,25 @@
  * fetchStargazers is mocked so no real network is hit.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
 
 // ---------------------------------------------------------------------------
 // Mock the data-layer module before importing the route handler.
 // ---------------------------------------------------------------------------
-vi.mock("@/lib/github-stargazers", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/lib/github-stargazers")>();
-  return {
-    ...actual,
-    fetchStargazers: vi.fn(),
-  };
-});
+const actual = await import("@/lib/github-stargazers");
+const mockFetchStargazers = mock();
 
-import { GET } from "@/app/api/stargazers/route";
-import {
-  StargazersError,
-  fetchStargazers,
-} from "@/lib/github-stargazers";
+mock.module("@/lib/github-stargazers", () => ({
+  ...actual,
+  fetchStargazers: mockFetchStargazers,
+}));
 
-const mockFetchStargazers = vi.mocked(fetchStargazers);
+const { GET } = await import("@/app/api/stargazers/route");
+const { StargazersError } = actual;
 
 afterEach(() => {
-  vi.clearAllMocks();
+  mockFetchStargazers.mockClear();
   delete process.env.GITHUB_TOKEN;
 });
 
@@ -38,11 +33,11 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 /** Build a minimal NextRequest-compatible object. */
-function makeRequest(repoParam?: string): Request {
+function makeRequest(repoParam?: string): NextRequest {
   const url = repoParam
     ? `http://localhost/api/stargazers?repo=${encodeURIComponent(repoParam)}`
     : "http://localhost/api/stargazers";
-  return new Request(url);
+  return new NextRequest(url);
 }
 
 const SAMPLE_STARGAZERS = [

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.2.0",
         "@tailwindcss/postcss": "^4",
+        "@types/bun": "latest",
         "@types/culori": "^4.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -580,6 +581,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/css-font-loading-module": ["@types/css-font-loading-module@0.0.7", "", {}, "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="],
 
     "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
@@ -735,6 +738,8 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/lib/__tests__/github-stargazers.test.ts
+++ b/lib/__tests__/github-stargazers.test.ts
@@ -6,7 +6,7 @@
  * All network is mocked — no real GitHub requests are made.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, jest, mock } from "bun:test";
 import {
   type Stargazer,
   StargazersError,
@@ -129,7 +129,7 @@ describe("fetchStargazers", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
     delete process.env.GITHUB_TOKEN;
   });
 
@@ -168,8 +168,7 @@ describe("fetchStargazers", () => {
     const repoBody = { stargazers_count: 1 };
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -192,8 +191,7 @@ describe("fetchStargazers", () => {
       rawEntry("bob", "2022-01-02T00:00:00Z"),
     ];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -207,8 +205,7 @@ describe("fetchStargazers", () => {
     // Only one page worth of data returned
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -224,8 +221,7 @@ describe("fetchStargazers", () => {
       rawEntry(`user${i}`, `2021-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`),
     );
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -247,7 +243,7 @@ describe("fetchStargazers", () => {
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
     // Repo fetch + each sampled stargazer page returns the same one-entry body.
-    global.fetch = vi.fn().mockImplementation((url: string) => {
+    global.fetch = mock().mockImplementation((url: string) => {
       if (String(url).includes("/repos/test/repo") && !String(url).includes("stargazers")) {
         return Promise.resolve(mockResponse(repoBody));
       }
@@ -265,8 +261,7 @@ describe("fetchStargazers", () => {
     const linkHeader = null; // only one page
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -275,8 +270,7 @@ describe("fetchStargazers", () => {
   });
 
   it("maps 404 response to StargazersError with code 'not_found'", async () => {
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse({}, { status: 404 }));
 
     await expect(
@@ -285,7 +279,7 @@ describe("fetchStargazers", () => {
   });
 
   it("maps 403 with x-ratelimit-remaining:0 to code 'rate_limited'", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(
+    global.fetch = mock().mockResolvedValueOnce(
       mockResponse(
         { message: "API rate limit exceeded" },
         { status: 403, headers: { "x-ratelimit-remaining": "0" } },
@@ -298,8 +292,7 @@ describe("fetchStargazers", () => {
   });
 
   it("maps 429 response to code 'rate_limited'", async () => {
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse({}, { status: 429 }));
 
     await expect(
@@ -310,8 +303,7 @@ describe("fetchStargazers", () => {
   it("handles 0-star repo: returns [] and totalStars 0 without throwing", async () => {
     const repoBody = { stargazers_count: 0 };
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody));
 
     const result = await fetchStargazers({ owner: "test", repo: "repo" });
@@ -326,8 +318,7 @@ describe("fetchStargazers", () => {
     const repoBody = { stargazers_count: 1 };
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 
@@ -340,8 +331,7 @@ describe("fetchStargazers", () => {
     const repoBody = { stargazers_count: 1 };
     const starBody = [rawEntry("alice", "2021-01-01T00:00:00Z")];
 
-    const fetchMock = vi
-      .fn()
+    const fetchMock = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
     global.fetch = fetchMock;
@@ -362,8 +352,7 @@ describe("fetchStargazers", () => {
       { starred_at: null, user: { login: "bob", avatar_url: "https://example.com/b.png" } }, // no date
     ];
 
-    global.fetch = vi
-      .fn()
+    global.fetch = mock()
       .mockResolvedValueOnce(mockResponse(repoBody))
       .mockResolvedValueOnce(mockResponse(starBody));
 

--- a/lib/server/__tests__/rate-limit.test.ts
+++ b/lib/server/__tests__/rate-limit.test.ts
@@ -20,15 +20,23 @@
  * requirement.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 
 // Mock server-only so importing the module doesn't blow up outside Next.js.
-vi.mock("server-only", () => ({}));
+mock.module("server-only", () => ({}));
 
-import { checkRateLimit } from "@/lib/server/rate-limit";
+const { checkRateLimit } = await import("@/lib/server/rate-limit");
 
 // ---------------------------------------------------------------------------
-// Reset env and timers between tests
+// Reset env and clock between tests
 // ---------------------------------------------------------------------------
 
 let ipCounter = 0;
@@ -37,15 +45,22 @@ function freshIp(): string {
   return `10.0.0.${++ipCounter}`;
 }
 
+let clock = 0;
+function advanceClock(ms: number): void {
+  clock += ms;
+  setSystemTime(new Date(clock));
+}
+
 beforeEach(() => {
-  vi.useFakeTimers();
+  clock = Date.UTC(2024, 0, 1);
+  setSystemTime(new Date(clock));
   // Defaults mirror the module defaults: capacity 5, full refill over 60 s.
   process.env.RENDER_RATE_LIMIT = "5";
   process.env.RENDER_RATE_WINDOW_MS = "60000";
 });
 
 afterEach(() => {
-  vi.useRealTimers();
+  setSystemTime();
   delete process.env.RENDER_RATE_LIMIT;
   delete process.env.RENDER_RATE_WINDOW_MS;
 });
@@ -126,7 +141,7 @@ describe("checkRateLimit — token refill", () => {
     checkRateLimit(ip); // consume the single token
     expect(checkRateLimit(ip)).toBe(false); // blocked
 
-    vi.advanceTimersByTime(60_000); // one full refill period
+    advanceClock(60_000); // one full refill period
     expect(checkRateLimit(ip)).toBe(true); // refilled
   });
 
@@ -140,7 +155,7 @@ describe("checkRateLimit — token refill", () => {
     expect(checkRateLimit(ip)).toBe(false);
 
     // Advance far past the window — tokens must cap at capacity (2).
-    vi.advanceTimersByTime(10 * 60_000);
+    advanceClock(10 * 60_000);
     expect(checkRateLimit(ip)).toBe(true);
     expect(checkRateLimit(ip)).toBe(true);
     expect(checkRateLimit(ip)).toBe(false); // 3rd blocked
@@ -154,7 +169,7 @@ describe("checkRateLimit — token refill", () => {
     checkRateLimit(ip); // consume
     expect(checkRateLimit(ip)).toBe(false);
 
-    vi.advanceTimersByTime(30_000); // exactly one token back
+    advanceClock(30_000); // exactly one token back
     expect(checkRateLimit(ip)).toBe(true);
     expect(checkRateLimit(ip)).toBe(false); // consumed again
   });

--- a/lib/server/__tests__/render-queue.test.ts
+++ b/lib/server/__tests__/render-queue.test.ts
@@ -18,32 +18,26 @@
  * sufficient.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { RenderInput } from "@/lib/server/validate-input";
 
 // ---------------------------------------------------------------------------
 // Mock the render module (real Chromium → deferred promise under test control)
 // ---------------------------------------------------------------------------
 
-vi.mock("@/lib/server/render", () => ({
-  renderStarsVideo: vi.fn(),
+const mockRender = mock();
+
+mock.module("@/lib/server/render", () => ({
+  renderStarsVideo: mockRender,
 }));
 
 // Mock mkdir so no real fs ops happen.
-vi.mock("node:fs/promises", () => ({
-  mkdir: vi.fn().mockResolvedValue(undefined),
+mock.module("node:fs/promises", () => ({
+  mkdir: mock(() => Promise.resolve(undefined)),
 }));
 
-// Mock server-only so it doesn't blow up in vitest.
-vi.mock("server-only", () => ({}));
+// Mock server-only so it doesn't blow up outside Next.js.
+mock.module("server-only", () => ({}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -89,27 +83,19 @@ const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 // Import queue + mock render fn after all vi.mock() calls are hoisted.
 // ---------------------------------------------------------------------------
 
-import { enqueueRender, getJob } from "@/lib/server/render-queue";
-import { renderStarsVideo } from "@/lib/server/render";
-
-const mockRender = renderStarsVideo as unknown as MockInstance<
-  Parameters<typeof renderStarsVideo>,
-  ReturnType<typeof renderStarsVideo>
->;
+const { enqueueRender, getJob } = await import("@/lib/server/render-queue");
 
 // ---------------------------------------------------------------------------
 // Reset mock state between tests (the module singleton is shared across the
-// file because vitest re-uses the same module instance within a test file).
+// file because bun re-uses the same module instance within a test file).
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  vi.useFakeTimers();
   mockRender.mockReset();
 });
 
 afterEach(() => {
-  vi.useRealTimers();
-  vi.clearAllMocks();
+  mockRender.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -290,8 +276,8 @@ describe("render-queue — render timeout", () => {
     const jobId = enqueueRender(makeInput());
     await tick();
 
-    // Advance fake timers past the timeout.
-    vi.advanceTimersByTime(1100);
+    // Wait past the timeout so the AbortController fires.
+    await new Promise((r) => setTimeout(r, 1100));
     await tick();
     await tick();
 

--- a/lib/server/__tests__/validate-input.test.ts
+++ b/lib/server/__tests__/validate-input.test.ts
@@ -6,8 +6,13 @@
  * Pure function — no mocks needed; all logic is deterministic.
  */
 
-import { describe, expect, it } from "vitest";
-import { parseRenderInput, RenderInputError } from "@/lib/server/validate-input";
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { parseRenderInput, RenderInputError } = await import(
+  "@/lib/server/validate-input"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "bun test",
     "lint": "biome check",
     "format": "biome format --write",
     "registry:build": "shadcn build",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
     "@tailwindcss/postcss": "^4",
+    "@types/bun": "latest",
     "@types/culori": "^4.0.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/registry/remocn-ui/caret/__tests__/caret.test.ts
+++ b/registry/remocn-ui/caret/__tests__/caret.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { caretBlinkOpacity } from "../index";
 

--- a/registry/remocn-ui/core/__tests__/README.md
+++ b/registry/remocn-ui/core/__tests__/README.md
@@ -17,15 +17,12 @@ bun test registry/remocn-ui/core/__tests__
 `color.ts` was rewritten to wrap the **`culori`** package, which is already
 declared in `package.json` (`culori` + `@types/culori`). Run `bun install`
 first so it lands in `node_modules`, or `color.test.ts` will fail to resolve the
-import. The test runner itself still needs nothing: these tests import
-`bun:test`, not `vitest`/`jest`, so no test script or test-framework dep is
-added to `package.json`.
+import. The test runner itself needs no third-party dep: these tests import
+`bun:test`, not any external framework. A `test` script (`bun test`) is defined
+in `package.json`; run the whole suite with `bun run test`.
 
-> If you would rather standardize on a framework later, the lightest path that
-> needs a dep is **vitest**: `bunx vitest run registry/remocn-ui/core` after
-> `bun add -d vitest`. The test bodies are framework-agnostic (`describe/it/
-> expect`); only the top `import { ... } from "bun:test"` line would change to
-> `from "vitest"`. Not required for Iteration 1.
+> The repo standardizes on `bun:test` as the single test framework — one runner,
+> no extra test-framework dependency.
 
 ## What is covered
 

--- a/registry/remocn/a1-product-demo/__tests__/a1-product-demo.test.ts
+++ b/registry/remocn/a1-product-demo/__tests__/a1-product-demo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import {
   getProductDemoDuration,
   planTransitionTiming,

--- a/registry/remocn/chat-gpt/__tests__/chat-gpt.test.ts
+++ b/registry/remocn/chat-gpt/__tests__/chat-gpt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { TYPING_CPS, TYPING_START_FRAME, morphProgressAt } from "../index";
 

--- a/registry/remocn/claude-chat/__tests__/claude-chat.test.ts
+++ b/registry/remocn/claude-chat/__tests__/claude-chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { TYPING_CPS, TYPING_START_FRAME, morphProgressAt } from "../index";
 

--- a/registry/remocn/claude-code/__tests__/claude-code.test.ts
+++ b/registry/remocn/claude-code/__tests__/claude-code.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { TYPING_CPS, TYPING_START_FRAME, WHATS_NEW } from "../index";
 
 describe("claude-code timing constants", () => {

--- a/registry/remocn/confetti/__tests__/confetti.test.ts
+++ b/registry/remocn/confetti/__tests__/confetti.test.ts
@@ -8,7 +8,7 @@
  * No React DOM or Remotion player needed — only pure JS logic is exercised.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { makeParticles, mulberry32, particleOpacity } from "../index";
 

--- a/registry/remocn/github-sponsors/__tests__/github-sponsors.test.ts
+++ b/registry/remocn/github-sponsors/__tests__/github-sponsors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import {
   SAMPLE_SPONSORS,

--- a/registry/remocn/github-stars/__tests__/github-stars.test.ts
+++ b/registry/remocn/github-stars/__tests__/github-stars.test.ts
@@ -9,7 +9,7 @@
  * All tests are fully deterministic (no network, no Date.now).
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import {
   SAMPLE_STARGAZERS,

--- a/registry/remocn/opencode/__tests__/opencode.test.ts
+++ b/registry/remocn/opencode/__tests__/opencode.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { THEMES, TYPING_CPS, TYPING_START_FRAME } from "../index";
 

--- a/registry/remocn/v0/__tests__/v0.test.ts
+++ b/registry/remocn/v0/__tests__/v0.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { TYPING_CPS, TYPING_START_FRAME, morphProgressAt } from "../index";
 

--- a/registry/remocn/x-followers-overview/__tests__/x-followers-overview.test.ts
+++ b/registry/remocn/x-followers-overview/__tests__/x-followers-overview.test.ts
@@ -9,7 +9,7 @@
  * All tests are fully deterministic (no network, no Date.now).
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { blurIn, flipEase, slotProgress } from "../index";
 


### PR DESCRIPTION
Ports the 17 remaining vitest-authored test files to bun:test so the repo runs on a single test framework, and adds a `test` script (`bun test`) plus `@types/bun`. Implements plan `plans/003`.

What changed:
- `package.json`: `"test": "bun test"` + `@types/bun` devDep
- 11 registry suites: import specifier swap only
- 6 lib/api suites: `vi.mock` → `mock.module` (module-scope mock instances + top-level `await import` so mocks register before the module-under-test loads), `vi.fn` → `mock`, `vi.restoreAllMocks` → `jest.restoreAllMocks`. Fake timers replaced with `setSystemTime` + manual clock (rate-limit) or a real wait (render-queue timeout), since bun 1.3.2 lacks `advanceTimersByTime`. Stargazers route test now builds a `NextRequest` (the route reads `request.nextUrl`)
- Corrected a stale test README that suggested adding vitest

Result: baseline 2392 pass / 21 fail / 4 errors → **2484 pass / 14 fail / 0 errors**. Framework errors eliminated; render-pipeline tests all pass.

**Reviewers must note** — this does NOT reach "0 fail". All 14 remaining failures were already red at baseline, none introduced here:
- 12 in pre-existing out-of-scope bun:test remocn-ui files (blur-in, cursor, combobox, command-menu, core/timeline, toggle-group, toast)
- 2 real bugs surfaced but not fixed (per plan scope): duplicate logins in github-stars `SAMPLE_STARGAZERS`, and a `fetchStargazers` downsample pagination/test mismatch

These should be triaged separately. No source (non-test) files were modified.

**Merge order:** merge after #56 and #57 (package.json/bun.lock overlap); this branch will be rebased once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)