### PR TITLE
fix(security): restrict render avatarUrl to GitHub avatar host allowlist

### DIFF
--- a/lib/server/__tests__/validate-input.test.ts
+++ b/lib/server/__tests__/validate-input.test.ts
@@ -99,7 +99,10 @@ describe("parseRenderInput — valid payload", () => {
 
   it("accepts stargazers array of exactly 60 items", () => {
     const many = Array.from({ length: 60 }, (_, i) =>
-      stargazer({ login: `user${i}`, avatarUrl: `https://example.com/u/${i}` }),
+      stargazer({
+        login: `user${i}`,
+        avatarUrl: `https://avatars.githubusercontent.com/u/${i}`,
+      }),
     );
     const result = parseRenderInput(validBody({ stargazers: many }));
     expect(result.stargazers).toHaveLength(60);
@@ -296,10 +299,10 @@ describe("parseRenderInput — stargazer item shapes", () => {
 });
 
 // ---------------------------------------------------------------------------
-// avatarUrl — http(s) enforcement (SSRF surface narrowing)
+// avatarUrl — GitHub avatar host allowlist (closes the SSRF window)
 // ---------------------------------------------------------------------------
 
-describe("parseRenderInput — avatarUrl must be http(s)", () => {
+describe("parseRenderInput — avatarUrl must be a GitHub avatar URL", () => {
   it("throws on a file:// avatarUrl", () => {
     expect(() =>
       parseRenderInput(
@@ -324,14 +327,7 @@ describe("parseRenderInput — avatarUrl must be http(s)", () => {
     ).toThrow(RenderInputError);
   });
 
-  it("accepts an http:// avatarUrl", () => {
-    const result = parseRenderInput(
-      validBody({ stargazers: [stargazer({ avatarUrl: "http://example.com/avatar.png" })] }),
-    );
-    expect(result.stargazers[0].avatarUrl).toBe("http://example.com/avatar.png");
-  });
-
-  it("accepts an https:// avatarUrl", () => {
+  it("accepts an https:// avatarUrl on the GitHub avatar host", () => {
     const result = parseRenderInput(
       validBody({
         stargazers: [stargazer({ avatarUrl: "https://avatars.githubusercontent.com/u/99" })],
@@ -340,6 +336,91 @@ describe("parseRenderInput — avatarUrl must be http(s)", () => {
     expect(result.stargazers[0].avatarUrl).toBe(
       "https://avatars.githubusercontent.com/u/99",
     );
+  });
+
+  it("accepts a GitHub avatar URL with a query string", () => {
+    const result = parseRenderInput(
+      validBody({
+        stargazers: [
+          stargazer({ avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4" }),
+        ],
+      }),
+    );
+    expect(result.stargazers[0].avatarUrl).toBe(
+      "https://avatars.githubusercontent.com/u/1?v=4",
+    );
+  });
+
+  it("rejects an http:// downgrade of the GitHub avatar host", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({
+          stargazers: [stargazer({ avatarUrl: "http://avatars.githubusercontent.com/u/1" })],
+        }),
+      ),
+    ).toThrow(RenderInputError);
+  });
+
+  it("rejects a non-GitHub https host", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({ stargazers: [stargazer({ avatarUrl: "https://evil.example.com/a.png" })] }),
+      ),
+    ).toThrow(RenderInputError);
+  });
+
+  it("rejects a loopback IP avatarUrl", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({ stargazers: [stargazer({ avatarUrl: "http://127.0.0.1:8080/x" })] }),
+      ),
+    ).toThrow(RenderInputError);
+  });
+
+  it("rejects the cloud metadata IP avatarUrl", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({
+          stargazers: [
+            stargazer({ avatarUrl: "http://169.254.169.254/latest/meta-data" }),
+          ],
+        }),
+      ),
+    ).toThrow(RenderInputError);
+  });
+
+  it("rejects an IPv6 loopback avatarUrl", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({ stargazers: [stargazer({ avatarUrl: "https://[::1]/x" })] }),
+      ),
+    ).toThrow(RenderInputError);
+  });
+
+  it("throws a 400 RenderInputError on an unparseable URL", () => {
+    expect(() =>
+      parseRenderInput(validBody({ stargazers: [stargazer({ avatarUrl: "not a url" })] })),
+    ).toThrow(RenderInputError);
+  });
+
+  it("throws a 400 RenderInputError on a scheme-only URL", () => {
+    expect(() =>
+      parseRenderInput(validBody({ stargazers: [stargazer({ avatarUrl: "https://" })] })),
+    ).toThrow(RenderInputError);
+  });
+
+  it("rejects a hostname that merely starts with the allowed host (subdomain spoof)", () => {
+    expect(() =>
+      parseRenderInput(
+        validBody({
+          stargazers: [
+            stargazer({
+              avatarUrl: "https://avatars.githubusercontent.com.evil.com/x",
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(RenderInputError);
   });
 });
 

--- a/lib/server/validate-input.ts
+++ b/lib/server/validate-input.ts
@@ -4,9 +4,10 @@ import "server-only";
  * Strict server-side validation of the render payload. Renders cost real CPU on
  * the box, so this is the gate that stops a crafted/oversized request from
  * blowing up Chromium: caps the stargazer count + string sizes, enums the
- * orientation/theme, clamps the numbers, and only lets http(s) avatar URLs
- * through (avatars are fetched by the headless browser → http(s)-only narrows
- * the SSRF surface). Throws a typed 400 error on anything outside the rules.
+ * orientation/theme, clamps the numbers, and only lets avatar URLs through
+ * whose host is on the GitHub avatar allowlist (avatars are fetched by the
+ * headless browser → pinning the host closes the SSRF window instead of just
+ * narrowing it). Throws a typed 400 error on anything outside the rules.
  */
 
 export type Orientation = "horizontal" | "vertical";
@@ -49,7 +50,7 @@ const MIN_SPEED = 1;
 const MAX_SPEED = 4;
 
 const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
-const HTTP_URL = /^https?:\/\//i;
+const ALLOWED_AVATAR_HOSTS = new Set(["avatars.githubusercontent.com"]);
 
 const DEFAULT_ACCENT = "#ffbb00";
 const DEFAULT_SPEED = 1;
@@ -96,9 +97,20 @@ function parseStargazer(value: unknown, index: number): RenderStargazer {
     `stargazers[${index}].avatarUrl`,
     MAX_AVATAR_URL_LEN,
   );
-  if (!HTTP_URL.test(avatarUrl)) {
+  let parsedAvatarUrl: URL;
+  try {
+    parsedAvatarUrl = new URL(avatarUrl);
+  } catch {
     throw new RenderInputError(
-      `stargazers[${index}].avatarUrl must be an http(s) URL`,
+      `stargazers[${index}].avatarUrl must be a valid URL`,
+    );
+  }
+  if (
+    parsedAvatarUrl.protocol !== "https:" ||
+    !ALLOWED_AVATAR_HOSTS.has(parsedAvatarUrl.hostname)
+  ) {
+    throw new RenderInputError(
+      `stargazers[${index}].avatarUrl must be a GitHub avatar URL`,
     );
   }
   const starredAt = requireString(


### PR DESCRIPTION
## What
`parseStargazer` in `lib/server/validate-input.ts` now validates `avatarUrl` via `new URL()` and requires `protocol === "https:"` plus `hostname` in a fixed allowlist (`avatars.githubusercontent.com`), replacing the old `/^https?:\/\//i` regex check.

## Why
`POST /api/render` inputProps (including stargazer avatarUrl) feed a server-side headless Chromium render that fetches each URL from the render box's network position. The old check accepted any http(s) URL, including `http://127.0.0.1/...`, RFC1918 ranges, and `http://169.254.169.254/...` (cloud metadata) — a blind SSRF vector. Legitimate avatarUrls are always GitHub-API-sourced (`avatars.githubusercontent.com`), confirmed in `lib/github-stargazers.ts` and `app/(home)/stars/**` — no other host is ever produced client-side, so the strict allowlist loses no legitimate functionality.

Tests: 58 pass / 0 fail in `validate-input.test.ts` (10 new avatar-host cases, incl. rejection of the http:// downgrade of the GitHub host). Full suite: 2492 pass / 14 fail — the same 14 pre-existing known failures, none related.

Ref: `plans/007-ssrf-avatar-url-allowlist.md`

## Reviewers should check
- Two pre-existing tests asserted acceptance of arbitrary non-GitHub http(s) avatar URLs; they were updated to the new stricter contract rather than left red — confirm that's the intended resolution.
- Error messages intentionally do NOT echo the submitted URL back (generic message, field index only).
- Out of scope by design: egress firewall / IP-range denylisting stays an infra-layer follow-up (block RFC1918 + link-local from the Chromium render process), not code here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)