### PR TITLE
fix(render): trust proxy-set client IP and cap render queue depth

### DIFF
--- a/app/api/render/__tests__/route.test.ts
+++ b/app/api/render/__tests__/route.test.ts
@@ -21,9 +21,17 @@ const mockCheckRate = mock();
 
 mock.module("server-only", () => ({}));
 
+class MockQueueFullError extends Error {
+  constructor() {
+    super("Render queue is full");
+    this.name = "QueueFullError";
+  }
+}
+
 mock.module("@/lib/server/render-queue", () => ({
   enqueueRender: mockEnqueue,
   getJob: mockGetJob,
+  QueueFullError: MockQueueFullError,
 }));
 
 mock.module("@/lib/server/rate-limit", () => ({
@@ -55,12 +63,17 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 /** Build a minimal NextRequest-compatible Request for POST /api/render. */
-function makePostRequest(body: unknown, ip = "1.2.3.4"): Request {
+function makePostRequest(
+  body: unknown,
+  ip = "1.2.3.4",
+  extraHeaders?: Record<string, string>,
+): Request {
   return new Request("http://localhost/api/render", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-forwarded-for": ip,
+      ...extraHeaders,
     },
     body: typeof body === "string" ? body : JSON.stringify(body),
   });
@@ -243,6 +256,28 @@ describe("POST /api/render — 202 success", () => {
     expect(mockCheckRate).toHaveBeenCalledWith("203.0.113.1");
   });
 
+  it("uses the LAST hop of a spoofed x-forwarded-for, not the client-controlled first hop", async () => {
+    mockCheckRate.mockReturnValue(true);
+    mockEnqueue.mockReturnValue("job-spoof-test");
+
+    await POST(makePostRequest(validPayload(), "1.1.1.1, 9.9.9.9") as never);
+
+    expect(mockCheckRate).toHaveBeenCalledWith("9.9.9.9");
+  });
+
+  it("prefers x-real-ip over x-forwarded-for when both are present", async () => {
+    mockCheckRate.mockReturnValue(true);
+    mockEnqueue.mockReturnValue("job-real-ip-test");
+
+    await POST(
+      makePostRequest(validPayload(), "1.1.1.1, 9.9.9.9", {
+        "x-real-ip": "2.2.2.2",
+      }) as never,
+    );
+
+    expect(mockCheckRate).toHaveBeenCalledWith("2.2.2.2");
+  });
+
   it("returns only { jobId } in the 202 body — no extra fields", async () => {
     mockCheckRate.mockReturnValue(true);
     mockEnqueue.mockReturnValue("clean-job");
@@ -250,6 +285,25 @@ describe("POST /api/render — 202 success", () => {
     const res = await POST(makePostRequest(validPayload()) as never);
     const body = await res.json();
     expect(Object.keys(body)).toEqual(["jobId"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/render — 503 queue full
+// ---------------------------------------------------------------------------
+
+describe("POST /api/render — 503 queue full", () => {
+  it("returns 503 with code queue_full when enqueueRender throws QueueFullError", async () => {
+    mockCheckRate.mockReturnValue(true);
+    mockEnqueue.mockImplementationOnce(() => {
+      throw new MockQueueFullError();
+    });
+
+    const res = await POST(makePostRequest(validPayload()) as never);
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("queue_full");
   });
 });
 

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 
 import { parseRenderInput, RenderInputError } from "@/lib/server/validate-input";
-import { enqueueRender } from "@/lib/server/render-queue";
+import { enqueueRender, QueueFullError } from "@/lib/server/render-queue";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import { ensureCleanupSweep } from "@/lib/server/cleanup";
 
@@ -53,16 +53,37 @@ export async function POST(request: NextRequest) {
     throw err;
   }
 
-  const jobId = enqueueRender(input);
+  let jobId: string;
+  try {
+    jobId = enqueueRender(input);
+  } catch (err) {
+    if (err instanceof QueueFullError) {
+      return NextResponse.json(
+        { error: "Render queue is full. Please retry shortly.", code: "queue_full" },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+
   return NextResponse.json({ jobId }, { status: 202 });
 }
 
-/** First hop of x-forwarded-for (the real client behind the proxy), else fallback. */
+/**
+ * The real client IP, trusting only what Traefik (the one proxy in front of
+ * this process) sets: `x-real-ip`, or else the LAST hop of `x-forwarded-for`
+ * (Traefik appends the peer; earlier hops are client-controlled and spoofable).
+ */
 function clientIp(request: NextRequest): string {
+  const realIp = request.headers.get("x-real-ip")?.trim();
+  if (realIp) return realIp;
+
   const forwarded = request.headers.get("x-forwarded-for");
   if (forwarded) {
-    const first = forwarded.split(",")[0]?.trim();
-    if (first) return first;
+    const parts = forwarded.split(",");
+    const last = parts[parts.length - 1]?.trim();
+    if (last) return last;
   }
-  return request.headers.get("x-real-ip")?.trim() || "unknown";
+
+  return "unknown";
 }

--- a/lib/server/__tests__/render-queue.test.ts
+++ b/lib/server/__tests__/render-queue.test.ts
@@ -83,7 +83,7 @@ const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 // Import queue + mock render fn after all vi.mock() calls are hoisted.
 // ---------------------------------------------------------------------------
 
-const { enqueueRender, getJob } = await import("@/lib/server/render-queue");
+const { enqueueRender, getJob, QueueFullError } = await import("@/lib/server/render-queue");
 
 // ---------------------------------------------------------------------------
 // Reset mock state between tests (the module singleton is shared across the
@@ -287,6 +287,28 @@ describe("render-queue — render timeout", () => {
     expect(job!.error).toMatch(/timed out/i);
 
     delete process.env.RENDER_TIMEOUT_MS;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue depth cap — RENDER_MAX_QUEUE
+// ---------------------------------------------------------------------------
+
+describe("render-queue — queue depth cap", () => {
+  it("throws QueueFullError when RENDER_MAX_QUEUE is reached", async () => {
+    process.env.RENDER_MAX_QUEUE = "1";
+
+    const d = deferred();
+    mockRender.mockReturnValueOnce(d.promise);
+
+    enqueueRender(makeInput());
+    await tick();
+
+    expect(() => enqueueRender(makeInput())).toThrow(QueueFullError);
+
+    d.resolve("/tmp/out.mp4");
+    await tick();
+    delete process.env.RENDER_MAX_QUEUE;
   });
 });
 

--- a/lib/server/render-queue.ts
+++ b/lib/server/render-queue.ts
@@ -45,8 +45,22 @@ function renderTimeoutMs(): number {
   return Number.isFinite(parsed) && parsed >= 1000 ? Math.floor(parsed) : 120_000;
 }
 
+/** Max jobs allowed in flight or waiting before new ones are rejected. */
+function maxQueueDepth(): number {
+  const parsed = Number(process.env.RENDER_MAX_QUEUE);
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 10;
+}
+
 const limit = pLimit(maxConcurrent());
 const jobs = new Map<string, JobState>();
+
+/** Thrown by enqueueRender when the queue is already at maxQueueDepth(). */
+export class QueueFullError extends Error {
+  constructor() {
+    super("Render queue is full");
+    this.name = "QueueFullError";
+  }
+}
 
 /**
  * Register a render and kick it off through the concurrency limiter. Returns the
@@ -54,6 +68,10 @@ const jobs = new Map<string, JobState>();
  * the registry. Never await the returned render work in the request handler.
  */
 export function enqueueRender(input: RenderInput): string {
+  if (limit.activeCount + limit.pendingCount >= maxQueueDepth()) {
+    throw new QueueFullError();
+  }
+
   const jobId = randomUUID();
   const outputPath = path.join(RENDER_WORK_DIR, `${jobId}.mp4`);
 


### PR DESCRIPTION
## What
- `clientIp()` in `app/api/render/route.ts` now trusts `x-real-ip` (set by Traefik) first, falling back to the LAST hop of `x-forwarded-for`. The previous first-hop logic let any client bypass the per-IP rate limiter by rotating a self-supplied XFF header — Traefik only appends to client-sent XFF, never replaces it.
- `enqueueRender()` in `lib/server/render-queue.ts` enforces a queue-depth cap (`RENDER_MAX_QUEUE`, default 10, same env-parsing convention as `RENDER_MAX_CONCURRENT`) and throws an exported `QueueFullError` once `activeCount + pendingCount` reaches it; the route maps it to `503 { code: "queue_full" }` — 503 rather than 429 because a full queue is server-wide saturation, not a per-client signal.
- Tests extended: spoofed-XFF last-hop case, x-real-ip precedence, queue-full 503, queue-depth cap via `RENDER_MAX_QUEUE=1`.

Tests: focused `bun test lib/server app/api/render` → 97 pass / 0 fail (4 new). Full suite: 2488 pass / 14 fail — same known pre-existing set. Typecheck: zero new errors.

Plan: `plans/005-rate-limit-trusted-ip-and-queue-cap.md`

## Reviewers should check
- The 503-vs-429 choice for `queue_full` (intentional per the plan's maintenance notes).
- `.env.example` is gitignored, so the `RENDER_MAX_QUEUE` documentation line can't ship in this PR — it was applied directly to the local checkout; set the var on the render host if you want a non-default cap.
- `lib/server/rate-limit.ts` and `app/api/render/[jobId]/**` intentionally untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)