### PR TITLE
fix(dx): fix real type errors and re-enable typecheck in the build

### DIFF
--- a/app/api/render/[jobId]/download/route.ts
+++ b/app/api/render/[jobId]/download/route.ts
@@ -54,7 +54,9 @@ export async function GET(
     void deleteJobFile(jobId);
   });
 
-  const webStream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>;
+  const webStream = Readable.toWeb(
+    nodeStream,
+  ) as unknown as ReadableStream<Uint8Array>;
 
   return new Response(webStream, {
     status: 200,

--- a/config/sponsors.ts
+++ b/config/sponsors.ts
@@ -19,7 +19,7 @@ export type Sponsor = {
   layout?: "row" | "col";
 };
 
-export const sponsors: Sponsor[] = [
+export const sponsors: Sponsor[] = ([
   {
     id: "reactbits",
     name: "React Bits",
@@ -135,7 +135,7 @@ export const sponsors: Sponsor[] = [
     isPaste: false,
     layout: "row",
   },
-].filter((sponsor) => !sponsor.isPaste);
+] satisfies Sponsor[]).filter((sponsor) => !sponsor.isPaste);
 
 export function getGoldSponsors(): Sponsor[] {
   return sponsors.filter(

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -11,6 +11,7 @@ export type PreviewSurface =
 
 export type CtaId =
   | "hero_browse"
+  | "hero_ui_badge"
   | "bento_browse"
   | "final_cta"
   | "github_header";
@@ -19,7 +20,7 @@ type AnalyticsEvents = {
   install_command_copied: {
     component: string;
     package_manager: "pnpm" | "npm" | "yarn" | "bun" | "prompt";
-    surface: "docs" | "landing";
+    surface: "docs" | "landing" | "bento";
   };
   preview_played: {
     component: string;

--- a/lib/server/validate-input.ts
+++ b/lib/server/validate-input.ts
@@ -12,14 +12,14 @@ import "server-only";
 export type Orientation = "horizontal" | "vertical";
 export type Theme = "light" | "dark";
 
-export interface RenderStargazer {
+export type RenderStargazer = {
   login: string;
   avatarUrl: string;
   /** ISO date string, e.g. "2021-03-04" */
   starredAt: string;
-}
+};
 
-export interface RenderInput {
+export type RenderInput = {
   repo: string;
   totalStars: number;
   stargazers: RenderStargazer[];
@@ -27,7 +27,7 @@ export interface RenderInput {
   accentColor: string;
   speed: number;
   theme: Theme;
-}
+};
 
 /** Thrown on invalid input; carries the HTTP status the API route should map to. */
 export class RenderInputError extends Error {

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,11 +18,6 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
-  typescript: {
-    // Type-check ломается из-за коллизии @types/mdx × @react-three/fiber
-    // (см. mdx-components.tsx). Рантайм не затронут.
-    ignoreBuildErrors: true,
-  },
 };
 
 export default withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test": "bun test",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome format --write",
     "registry:build": "shadcn build",

--- a/registry/remocn-ui/dropdown-menu/config.ts
+++ b/registry/remocn-ui/dropdown-menu/config.ts
@@ -15,6 +15,9 @@ export const dropdownMenuConfig: ComponentConfig = {
     highlightedIndex: {
       type: "number",
       default: 0,
+      min: -1,
+      max: 3,
+      step: 1,
       label: "Highlighted Index",
     },
   },

--- a/registry/remocn/a1-product-demo/index.tsx
+++ b/registry/remocn/a1-product-demo/index.tsx
@@ -92,14 +92,6 @@ export const DEFAULT_PRODUCT_DEMO_CONFIG: ProductDemoConfig = {
   ],
 };
 
-function planPresentation(from: ProductDemoScene, to: ProductDemoScene) {
-  if (from.type === "feature-frame" && to.type === "feature-frame") {
-    const direction = to.content.side === "right" ? "left" : "right";
-    return spatialPush({ direction });
-  }
-  return cameraCraneUp();
-}
-
 function SceneBackground({
   scene,
   theme,
@@ -254,13 +246,25 @@ export function ProductDemo({
 
     const next = scenes[index + 1];
     if (next) {
-      nodes.push(
-        <TransitionSeries.Transition
-          key={`transition-${index}`}
-          presentation={planPresentation(scene, next)}
-          timing={resolveTiming(planTransitionTiming(scene, next))}
-        />,
-      );
+      const timing = resolveTiming(planTransitionTiming(scene, next));
+      if (scene.type === "feature-frame" && next.type === "feature-frame") {
+        const direction = next.content.side === "right" ? "left" : "right";
+        nodes.push(
+          <TransitionSeries.Transition
+            key={`transition-${index}`}
+            presentation={spatialPush({ direction })}
+            timing={timing}
+          />,
+        );
+      } else {
+        nodes.push(
+          <TransitionSeries.Transition
+            key={`transition-${index}`}
+            presentation={cameraCraneUp()}
+            timing={timing}
+          />,
+        );
+      }
     }
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
@@ -142,5 +143,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts",
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "**/__tests__/**"],
 }


### PR DESCRIPTION
Re-enables TypeScript checking that was fully disabled via `next.config.ts` `typescript.ignoreBuildErrors: true`.

## What
- Fixes all 9 genuine app-source type errors: two analytics unions (`hero_ui_badge`, `bento` surface), `RenderInput`/`RenderStargazer` `interface` → `type` (index-signature assignability on the render path), the `sponsors` array (contextual-typing loss from `.filter()`, fixed via `satisfies`), the dropdown-menu number control's missing `min/max/step`, and the a1-product-demo transition (invariant `TransitionPresentation<T>` — inlined into two concrete-typed branches)
- Excludes `**/__tests__/**` from typecheck (they run on `bun:test` since plan 003) and adds `allowImportingTsExtensions` for `render-demos.mts`
- Also fixes one error surfaced by the Next 16.2.10 bump in `download/route.ts` (node vs DOM `ReadableStream` identity)
- Removes `ignoreBuildErrors`, adds a `typecheck` script

## Why
No typecheck gate existed anywhere, so type regressions could deploy silently. This also unblocks the CI pipeline (plan 010), which gates on `bun run typecheck`.

Result: 9 app-source errors → 0, `bun run typecheck` exits 0. No `as any`/`@ts-ignore`/`@ts-expect-error` introduced. Lint not increased (569 ≤ 589 baseline).

Plan: `plans/002-re-enable-typecheck.md`

## Reviewers should check
- `config/sponsors.ts` (`satisfies`, no data change) and `registry/remocn/a1-product-demo/index.tsx` (transition decision inlined, behavior intended to be identical) — confirm the a1-product-demo animation is unchanged
- Run `bun run build` once to confirm the re-enabled typecheck gate passes in a real production build (not run here by policy)
- Touches `lib/server/validate-input.ts` like #62 does — if GitHub reports a conflict after one of them merges, I'll rebase the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)