### PR TITLE
Frame surfaces for docs + screen-studio timeline on landing

### DIFF
--- a/app/(home)/components/sections/how-it-works-viz.tsx
+++ b/app/(home)/components/sections/how-it-works-viz.tsx
@@ -78,6 +78,7 @@ export function AgentWindowViz({ play }: VizProps) {
 }
 
 const LOG_LINES = ["installing skill", "starting preview"];
+const PROMPT = "Set up a remocn project";
 
 export function PromptTypingViz({ play }: VizProps) {
   const reduced = useReducedMotion();
@@ -87,9 +88,7 @@ export function PromptTypingViz({ play }: VizProps) {
     return (
       <WindowFrame label="~/demo-video">
         <div className="flex h-full flex-col gap-2">
-          <p className="font-mono text-xs text-foreground">
-            › Set up a remocn project
-          </p>
+          <p className="font-mono text-xs text-foreground">› {PROMPT}</p>
           {LOG_LINES.map((line) => (
             <p
               key={line}
@@ -110,7 +109,14 @@ export function PromptTypingViz({ play }: VizProps) {
           <span className="shrink-0 text-muted-foreground/50">›</span>
           <motion.span
             className="overflow-hidden whitespace-nowrap text-foreground will-change-[width]"
-            animate={{ width: ["0%", "100%", "100%", "100%"] }}
+            animate={{
+              width: [
+                "0ch",
+                `${PROMPT.length}ch`,
+                `${PROMPT.length}ch`,
+                `${PROMPT.length}ch`,
+              ],
+            }}
             transition={{
               duration: LOOP,
               times: [0, 0.32, 0.92, 1],
@@ -118,7 +124,7 @@ export function PromptTypingViz({ play }: VizProps) {
               ease: "linear",
             }}
           >
-            Set up a remocn project
+            {PROMPT}
           </motion.span>
           <Caret active />
         </div>

--- a/app/(home)/components/sections/transitions-viz.tsx
+++ b/app/(home)/components/sections/transitions-viz.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Player, type PlayerRef } from "@remotion/player";
+import { linearTiming, TransitionSeries } from "@remotion/transitions";
+import { useReducedMotion } from "motion/react";
+import { useRef } from "react";
+import { AbsoluteFill } from "remotion";
+import { zoomBlur } from "@/registry/remocn/zoom-blur";
+import { useAutoplay } from "../use-autoplay";
+
+const SCENE_FRAMES = 55;
+const TRANSITION_FRAMES = 18;
+const DURATION = SCENE_FRAMES * 2 - TRANSITION_FRAMES;
+const FPS = 30;
+
+// Bare zoomBlur between two empty color fills — the transition's own motion
+// is the whole preview, no scene content to distract from it.
+function BareTransitionScene() {
+  return (
+    <TransitionSeries>
+      <TransitionSeries.Sequence durationInFrames={SCENE_FRAMES}>
+        <AbsoluteFill style={{ background: "#26242e" }} />
+      </TransitionSeries.Sequence>
+      <TransitionSeries.Transition
+        timing={linearTiming({ durationInFrames: TRANSITION_FRAMES })}
+        presentation={zoomBlur()}
+      />
+      <TransitionSeries.Sequence durationInFrames={SCENE_FRAMES}>
+        <AbsoluteFill style={{ background: "#141318" }} />
+      </TransitionSeries.Sequence>
+    </TransitionSeries>
+  );
+}
+
+export function TransitionsViz({ play }: { play: boolean }) {
+  const reduced = useReducedMotion();
+  const playerRef = useRef<PlayerRef>(null);
+  const { containerRef } = useAutoplay(playerRef, play && !reduced);
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 overflow-hidden">
+      <div className="absolute top-1/2 left-1/2 aspect-video min-h-full min-w-full -translate-x-1/2 -translate-y-1/2 will-change-transform">
+        <Player
+          ref={playerRef}
+          component={BareTransitionScene}
+          inputProps={{}}
+          durationInFrames={DURATION}
+          fps={FPS}
+          compositionWidth={1280}
+          compositionHeight={720}
+          style={{ width: "100%", height: "100%" }}
+          loop
+          initiallyMuted
+          acknowledgeRemotionLicense
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(home)/components/sections/whats-inside.tsx
+++ b/app/(home)/components/sections/whats-inside.tsx
@@ -8,19 +8,38 @@ import {
   Type,
   Waves,
 } from "lucide-react";
-import { motion, useInView, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  animate,
+  motion,
+  useInView,
+  useMotionValue,
+  useMotionValueEvent,
+  useReducedMotion,
+  useTransform,
+} from "motion/react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { type ComponentType, useRef } from "react";
-import { SPRING_SOFT } from "@/config/site";
+import { type ComponentType, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { SectionHeading } from "../section-heading";
 
-// The shader viz is the only tile that pulls @remotion/player + the shader
+// The shader viz is the only scene that pulls @remotion/player + the shader
 // runtime. Load it client-only so that weight leaves the initial landing
-// bundle; the tile is below the fold and its text/links stay server-rendered.
+// bundle; the track labels and links stay server-rendered.
 const ShadersViz = dynamic(
   () => import("./shaders-viz").then((m) => ({ default: m.ShadersViz })),
+  {
+    ssr: false,
+    loading: () => <div className="absolute inset-0 bg-muted/20" />,
+  },
+);
+
+// Same deal for the transitions scene — a real registry transition
+// (zoomBlur in a TransitionSeries) playing in @remotion/player.
+const TransitionsViz = dynamic(
+  () =>
+    import("./transitions-viz").then((m) => ({ default: m.TransitionsViz })),
   {
     ssr: false,
     loading: () => <div className="absolute inset-0 bg-muted/20" />,
@@ -31,6 +50,8 @@ const EYEBROW = "What’s inside";
 const TITLE = "Five kinds of building blocks";
 const LEAD =
   "Every remocn component belongs to one of these families. Your agent composes them on the timeline, one scene at a time.";
+
+const FPS = 30;
 
 interface VizProps {
   play: boolean;
@@ -70,74 +91,6 @@ function TypographyViz({ play }: VizProps) {
           {ch}
         </motion.span>
       ))}
-    </div>
-  );
-}
-
-function TransitionsViz({ play }: VizProps) {
-  const reduced = useReducedMotion();
-  const active = play && !reduced;
-
-  if (!active) {
-    return (
-      <div className="absolute inset-0 flex items-center justify-center bg-foreground">
-        <span className="font-mono text-3xl font-medium text-background">
-          02
-        </span>
-      </div>
-    );
-  }
-
-  const times = [0, 0.28, 0.42, 0.58, 0.72, 1];
-  const loop = {
-    duration: 3.4,
-    times,
-    repeat: Number.POSITIVE_INFINITY,
-    ease: "easeInOut" as const,
-  };
-
-  return (
-    <div className="absolute inset-0 overflow-hidden">
-      <motion.div
-        className="absolute inset-0 flex items-center justify-center bg-muted/50 will-change-[transform,opacity,filter]"
-        animate={{
-          opacity: [1, 1, 0, 0, 1, 1],
-          scale: [1, 1, 1.06, 0.97, 1, 1],
-          filter: [
-            "blur(0px) brightness(1)",
-            "blur(0px) brightness(1)",
-            "blur(14px) brightness(1.3)",
-            "blur(14px) brightness(1.25)",
-            "blur(0px) brightness(1)",
-            "blur(0px) brightness(1)",
-          ],
-        }}
-        transition={loop}
-      >
-        <span className="font-mono text-3xl font-medium text-muted-foreground">
-          01
-        </span>
-      </motion.div>
-      <motion.div
-        className="absolute inset-0 flex items-center justify-center bg-foreground will-change-[transform,opacity,filter]"
-        animate={{
-          opacity: [0, 0, 1, 1, 0, 0],
-          scale: [0.97, 0.97, 1, 1, 1.06, 0.97],
-          filter: [
-            "blur(14px) brightness(1.25)",
-            "blur(14px) brightness(1.25)",
-            "blur(0px) brightness(1)",
-            "blur(0px) brightness(1)",
-            "blur(14px) brightness(1.3)",
-            "blur(14px) brightness(1.25)",
-          ],
-        }}
-        transition={loop}
-      >
-        <span className="font-mono text-3xl font-medium text-background">
-          02
-        </span>
-      </motion.div>
     </div>
   );
 }
@@ -218,16 +171,19 @@ function UiPrimitivesViz({ play }: VizProps) {
   );
 }
 
-interface Category {
+interface Clip {
   title: string;
   description: string;
   href: string;
   icon: ComponentType<{ className?: string }>;
   Viz: ComponentType<VizProps>;
-  span: string;
+  /** Clip length in timeline seconds — sets its share of the track width. */
+  seconds: number;
+  /** Screen-studio-style saturated track color for the pill. */
+  fill: string;
 }
 
-const CATEGORIES: Category[] = [
+const CLIPS: Clip[] = [
   {
     title: "Typography",
     description:
@@ -235,7 +191,8 @@ const CATEGORIES: Category[] = [
     href: "/docs/typography",
     icon: Type,
     Viz: TypographyViz,
-    span: "lg:col-span-3",
+    seconds: 3.5,
+    fill: "oklch(0.62 0.12 60)",
   },
   {
     title: "Shaders",
@@ -244,7 +201,8 @@ const CATEGORIES: Category[] = [
     href: "/docs/shaders/getting-started/introduction",
     icon: Waves,
     Viz: ShadersViz,
-    span: "lg:col-span-3",
+    seconds: 3,
+    fill: "oklch(0.54 0.14 285)",
   },
   {
     title: "Transitions",
@@ -252,7 +210,8 @@ const CATEGORIES: Category[] = [
     href: "/docs/transitions",
     icon: Shuffle,
     Viz: TransitionsViz,
-    span: "lg:col-span-2",
+    seconds: 2,
+    fill: "oklch(0.57 0.1 220)",
   },
   {
     title: "Animated Icons",
@@ -260,7 +219,8 @@ const CATEGORIES: Category[] = [
     href: "/docs/icons/gallery",
     icon: Sparkles,
     Viz: AnimatedIconsViz,
-    span: "lg:col-span-2",
+    seconds: 2,
+    fill: "oklch(0.58 0.1 150)",
   },
   {
     title: "UI Primitives",
@@ -269,66 +229,97 @@ const CATEGORIES: Category[] = [
     href: "/docs/ui",
     icon: Component,
     Viz: UiPrimitivesViz,
-    span: "sm:col-span-2 lg:col-span-2",
+    seconds: 2.5,
+    fill: "oklch(0.54 0.13 330)",
   },
 ];
 
-function CategoryCard({ category }: { category: Category }) {
-  const ref = useRef<HTMLElement>(null);
-  const inView = useInView(ref, { amount: 0.4 });
-  const reduced = useReducedMotion();
-  const { Viz, icon: Icon } = category;
+const TOTAL_SECONDS = CLIPS.reduce((sum, clip) => sum + clip.seconds, 0);
+/** Cumulative clip start times, as 0–1 fractions of the whole track. */
+const CLIP_STARTS = CLIPS.reduce<number[]>((starts, _, i) => {
+  starts.push(
+    i === 0 ? 0 : starts[i - 1] + CLIPS[i - 1].seconds / TOTAL_SECONDS,
+  );
+  return starts;
+}, []);
 
+function clipIndexAt(progress: number) {
+  for (let i = CLIP_STARTS.length - 1; i >= 0; i--) {
+    if (progress >= CLIP_STARTS[i]) return i;
+  }
+  return 0;
+}
+
+function formatTimecode(seconds: number) {
+  const frames = Math.round(seconds * FPS);
+  return `${Math.floor(frames / FPS)}:${String(frames % FPS).padStart(2, "0")}`;
+}
+
+const RULER_STEPS = 13;
+
+function TimelineRuler() {
   return (
-    <div className={cn("h-full", category.span)}>
-      <Link
-        href={category.href}
-        aria-label={`Explore ${category.title}`}
-        className="group block h-full rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-      >
-        <motion.div whileHover="hover" className="h-full">
-          <motion.article
-            ref={ref}
-            variants={reduced ? undefined : { hover: { y: -4 } }}
-            transition={SPRING_SOFT}
-            className="surface-card relative flex h-full flex-col overflow-hidden rounded-3xl"
+    <div
+      aria-hidden
+      className="relative flex h-6 select-none items-end border-b border-border/60"
+    >
+      {Array.from({ length: RULER_STEPS + 1 }, (_, i) => {
+        const seconds = (TOTAL_SECONDS / RULER_STEPS) * i;
+        return (
+          <div
+            key={i}
+            className="absolute bottom-0 flex flex-col items-start gap-1"
+            style={{ left: `${(i / RULER_STEPS) * 100}%` }}
           >
-            <div
-              aria-hidden
-              className="pointer-events-none relative flex h-40 select-none items-center justify-center overflow-hidden border-b border-border bg-muted/20 sm:h-44"
-            >
-              <Viz play={inView} />
-            </div>
-            <div className="flex flex-1 flex-col p-5 sm:p-6">
-              <div className="flex items-center gap-2">
-                <Icon
-                  aria-hidden
-                  className="size-4 shrink-0 text-muted-foreground"
-                />
-                <h3 className="text-base font-semibold tracking-tight text-foreground">
-                  {category.title}
-                </h3>
-                <ArrowUpRight
-                  aria-hidden
-                  className="ml-auto size-4 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-foreground"
-                />
-              </div>
-              <p className="mt-2 text-sm leading-relaxed text-pretty text-muted-foreground">
-                {category.description}
-              </p>
-            </div>
-          </motion.article>
-        </motion.div>
-      </Link>
+            {i % 2 === 0 && i < RULER_STEPS && (
+              <span className="font-mono text-[10px] leading-none text-muted-foreground/50 tabular-nums">
+                {formatTimecode(seconds)}
+              </span>
+            )}
+            <span
+              className={cn("w-px bg-border", i % 2 === 0 ? "h-2" : "h-1")}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 export function WhatsInside() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const inView = useInView(sectionRef, { amount: 0.3 });
+  const reduced = useReducedMotion();
+
+  const progress = useMotionValue(0);
+  const playheadLeft = useTransform(progress, (v) => `${v * 100}%`);
+  const [playheadIndex, setPlayheadIndex] = useState(0);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  useMotionValueEvent(progress, "change", (v) => {
+    const idx = clipIndexAt(v);
+    if (idx !== playheadIndex) setPlayheadIndex(idx);
+  });
+
+  useEffect(() => {
+    if (!inView || reduced) return;
+    const controls = animate(progress, [0, 1], {
+      duration: TOTAL_SECONDS,
+      ease: "linear",
+      repeat: Number.POSITIVE_INFINITY,
+    });
+    return () => controls.stop();
+  }, [inView, reduced, progress]);
+
+  const activeIndex = hoverIndex ?? playheadIndex;
+  const activeClip = CLIPS[activeIndex];
+  const ActiveViz = activeClip.Viz;
+
   return (
     <section
+      ref={sectionRef}
       id="whats-inside"
-      className="relative py-14 sm:py-20 [content-visibility:auto] [contain-intrinsic-size:auto_640px]"
+      className="relative py-14 sm:py-20 [content-visibility:auto] [contain-intrinsic-size:auto_760px]"
     >
       <div className="section">
         <SectionHeading
@@ -338,10 +329,106 @@ export function WhatsInside() {
           animated={false}
         />
 
-        <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 sm:grid-cols-2 sm:gap-5 lg:grid-cols-6 lg:gap-6">
-          {CATEGORIES.map((category) => (
-            <CategoryCard key={category.title} category={category} />
-          ))}
+        {/* Monitor — the preview canvas above the timeline, editor-style. */}
+        <div className="relative mt-10 h-56 overflow-hidden rounded-2xl border border-border bg-muted/20 sm:mt-12 sm:h-72">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={activeClip.title}
+              initial={reduced ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={reduced ? undefined : { opacity: 0 }}
+              transition={{ duration: 0.18, ease: "easeOut" }}
+              className="pointer-events-none absolute inset-0 flex select-none items-center justify-center"
+            >
+              <ActiveViz play={inView} />
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        <div className="mt-6 overflow-x-auto">
+          <div className="relative min-w-[640px]">
+            <TimelineRuler />
+
+            <div className="relative mt-2">
+              {/* Playhead spans the ruler gap and the track. */}
+              {!reduced && (
+                <motion.div
+                  aria-hidden
+                  className="pointer-events-none absolute -top-8 bottom-0 z-10 flex flex-col items-center"
+                  style={{ left: playheadLeft }}
+                >
+                  <span className="size-2 shrink-0 rounded-[2px] bg-primary" />
+                  <span className="w-px flex-1 bg-primary" />
+                </motion.div>
+              )}
+
+              <div className="flex gap-1.5">
+                {CLIPS.map((clip, i) => {
+                  const active = i === activeIndex;
+                  const Icon = clip.icon;
+                  return (
+                    <Link
+                      key={clip.title}
+                      href={clip.href}
+                      aria-label={`Explore ${clip.title}`}
+                      style={{
+                        flexGrow: clip.seconds,
+                        flexBasis: 0,
+                        backgroundColor: clip.fill,
+                      }}
+                      onMouseEnter={() => setHoverIndex(i)}
+                      onMouseLeave={() => setHoverIndex(null)}
+                      onFocus={() => setHoverIndex(i)}
+                      onBlur={() => setHoverIndex(null)}
+                      className={cn(
+                        "group relative flex h-12 min-w-0 flex-col items-center justify-center gap-0.5 overflow-hidden rounded-xl px-3 transition-[opacity,filter] duration-200 sm:h-14",
+                        "inset-shadow-[0_1px_0_--theme(--color-white/25%)]",
+                        active
+                          ? "opacity-100"
+                          : "opacity-55 saturate-75 hover:opacity-80",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+                      )}
+                    >
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <Icon
+                          aria-hidden
+                          className="size-3.5 shrink-0 text-white/80"
+                        />
+                        <span className="truncate text-xs font-medium text-white">
+                          {clip.title}
+                        </span>
+                      </span>
+                      <span className="font-mono text-[10px] leading-none text-white/60 tabular-nums">
+                        {clip.seconds.toFixed(1)}s
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="mt-4 flex min-h-12 items-start justify-between gap-4">
+              <motion.p
+                key={activeClip.title}
+                initial={reduced ? false : { opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+                className="max-w-xl text-sm leading-relaxed text-pretty text-muted-foreground"
+              >
+                <span className="font-medium text-foreground">
+                  {activeClip.title}
+                </span>{" "}
+                — {activeClip.description}
+              </motion.p>
+              <Link
+                href={activeClip.href}
+                className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+              >
+                Explore
+                <ArrowUpRight aria-hidden className="size-4" />
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -24,18 +24,17 @@ export default async function Page(props: {
       footer={{ enabled: !isIcons }}
       className={isIcons ? "max-w-none" : undefined}
     >
-      <DocsTitle
-        style={{ fontFamily: "var(--font-display)" }}
-        className="text-4xl font-semibold tracking-tight text-balance md:text-5xl"
-      >
-        {data.title}
-      </DocsTitle>
-      <DocsDescription className="mt-3 mb-0 max-w-3xl text-pretty text-lg text-muted-foreground md:text-xl">
+      <div className="flex items-center justify-between gap-4">
+        <DocsTitle className="text-3xl font-semibold tracking-tight text-balance md:text-4xl">
+          {data.title}
+        </DocsTitle>
+        {params.slug?.length ? (
+          <CopyMarkdownButton url={`${page.url}.md`} className="shrink-0" />
+        ) : null}
+      </div>
+      <DocsDescription className="mt-3 mb-0 max-w-xl text-pretty text-base text-muted-foreground md:text-lg">
         {data.description}
       </DocsDescription>
-      {params.slug?.length ? (
-        <CopyMarkdownButton url={`${page.url}.md`} className="mt-4" />
-      ) : null}
       <div className="typeset typeset-docs mt-8 flex-1">
         <MDX components={getMDXComponents()} />
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -118,6 +118,13 @@
   --elevation-raised-highlighted:
     0 0 0 1px rgb(0 0 0 / 0.15), 0 1px 3px rgb(0 0 0 / 0.05), 0 4px 10px -4px
     rgb(0 0 0 / 0.05);
+
+  --elevation-control:
+    inset 0 1px 0 rgb(255 255 255 / 0.85), inset 0 0 0 1px rgb(0 0 0 / 0.08),
+    0 1px 2px rgb(0 0 0 / 0.05), 0 2px 4px -2px rgb(0 0 0 / 0.06);
+  --elevation-control-hover:
+    inset 0 1px 0 rgb(255 255 255 / 0.85), inset 0 0 0 1px rgb(0 0 0 / 0.12),
+    0 1px 2px rgb(0 0 0 / 0.06), 0 3px 6px -2px rgb(0 0 0 / 0.08);
 }
 
 .dark {
@@ -164,6 +171,13 @@
   --elevation-raised: 0 0 0 1px rgb(255 255 255 / 0.09);
   --elevation-raised-hover: 0 0 0 1px rgb(255 255 255 / 0.14);
   --elevation-raised-highlighted: 0 0 0 1px rgb(255 255 255 / 0.18);
+
+  --elevation-control:
+    inset 0 1px 0 rgb(255 255 255 / 0.05), inset 0 0 0 1px
+    rgb(255 255 255 / 0.08);
+  --elevation-control-hover:
+    inset 0 1px 0 rgb(255 255 255 / 0.07), inset 0 0 0 1px
+    rgb(255 255 255 / 0.12);
 }
 
 @layer base {
@@ -192,8 +206,23 @@
   @apply mx-auto w-full max-w-6xl px-4 sm:px-6 min-[1440px]:max-w-5xl;
 }
 
-.bg-control {
-  @apply bg-muted border border-border;
+.control-surface {
+  @apply bg-muted;
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--elevation-control);
+}
+
+.control-surface-interactive {
+  transition-property: color, background-color, box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.control-surface-interactive:hover {
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--elevation-control-hover);
 }
 
 .bg-grid-fade {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Manrope, Outfit } from "next/font/google";
+import { Geist, Geist_Mono, Manrope } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
@@ -16,11 +16,6 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-const outfit = Outfit({
-  variable: "--font-display",
   subsets: ["latin"],
 });
 
@@ -75,7 +70,6 @@ export default function RootLayout({
         "antialiased",
         geistSans.variable,
         geistMono.variable,
-        outfit.variable,
         "font-sans",
         inter.variable,
       )}

--- a/components.json
+++ b/components.json
@@ -22,6 +22,7 @@
     "hooks": "@/hooks"
   },
   "registries": {
+    "@coss": "https://coss.com/ui/r/{name}.json",
     "@react-bits": "https://reactbits.dev/r/{name}.json",
     "@svgl": "https://svgl.app/r/{name}.json",
     "@ncdai": "https://chanhdai.com/r/{name}.json"

--- a/components/docs/code-block-command.tsx
+++ b/components/docs/code-block-command.tsx
@@ -30,8 +30,10 @@ export interface CodeBlockCommandProps {
   /**
    * Surface treatment. `muted` (default) is the filled gray slab used in docs.
    * `outline` is a lighter bordered terminal that sits softer on light cards.
+   * `plain` is border- and background-less, for hosts that own the surface
+   * (e.g. a FramePanel).
    */
-  variant?: "muted" | "outline";
+  variant?: "muted" | "outline" | "plain";
 }
 
 export function CodeBlockCommand({
@@ -62,7 +64,8 @@ export function CodeBlockCommand({
     <div
       className={cn(
         "not-prose relative overflow-hidden rounded-xl",
-        variant === "outline" ? "border border-border bg-card" : "bg-muted",
+        variant === "outline" && "border border-border bg-card",
+        variant === "muted" && "bg-muted",
       )}
     >
       <TabsPrimitive.Root

--- a/components/docs/component-customizer.tsx
+++ b/components/docs/component-customizer.tsx
@@ -2,9 +2,13 @@
 
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { ChevronDownIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { ElasticSlider } from "@/components/ui/elastic-slider";
 import { Label } from "@/components/ui/label";
+import {
+  NumberField,
+  NumberFieldInput,
+  NumberFieldScrubArea,
+} from "@/components/ui/number-field";
 import { SelectContent, SelectItem } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import type { ControlConfig, ControlType } from "@/lib/customizer-config";
@@ -80,49 +84,24 @@ function NumberInputPill({
   value: number;
   onChange: (value: number) => void;
 }) {
-  const [draft, setDraft] = useState(String(value));
-  const committed = useRef(value);
-
-  useEffect(() => {
-    if (value !== committed.current) {
-      committed.current = value;
-      setDraft(String(value));
-    }
-  }, [value]);
-
-  const commit = (raw: string) => {
-    if (raw === "" || raw === "-") return;
-    const n = Number(raw);
-    if (Number.isNaN(n)) return;
-    const clamped = Math.min(ctrl.max, Math.max(ctrl.min, n));
-    committed.current = clamped;
-    onChange(clamped);
-  };
-
   return (
-    <div className={PILL}>
-      <Label
-        htmlFor={id}
-        className="shrink-0 font-medium text-muted-foreground"
-      >
-        {ctrl.label}
-      </Label>
-      <input
-        id={id}
-        type="number"
-        inputMode="numeric"
-        min={ctrl.min}
-        max={ctrl.max}
-        step={ctrl.step}
-        value={draft}
-        onChange={(e) => {
-          setDraft(e.target.value);
-          commit(e.target.value);
-        }}
-        onBlur={() => setDraft(String(committed.current))}
-        className="min-w-0 flex-1 bg-transparent text-right font-mono text-base font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/40 placeholder:text-muted-foreground/50 sm:text-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+    <NumberField
+      id={id}
+      value={value}
+      onValueChange={(v) => {
+        if (v !== null) onChange(v);
+      }}
+      min={ctrl.min}
+      max={ctrl.max}
+      step={ctrl.step}
+      className={cn(PILL, "flex-row justify-between")}
+    >
+      <NumberFieldScrubArea
+        label={ctrl.label}
+        className="shrink-0 text-muted-foreground"
       />
-    </div>
+      <NumberFieldInput className="h-auto min-w-0 flex-1 rounded-none px-0 text-right font-mono text-base font-medium leading-none text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/40 sm:h-auto sm:text-sm" />
+    </NumberField>
   );
 }
 

--- a/components/docs/component-customizer.tsx
+++ b/components/docs/component-customizer.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 
 /** Shared pill surface so every non-slider control matches the elastic slider. */
 const PILL =
-  "flex h-11 items-center gap-3 rounded-xl bg-control px-3 text-sm transition-colors";
+  "flex h-9 items-center gap-3 rounded-xl control-surface px-3 text-sm transition-colors";
 
 /** Strip trailing zeros so the value reads like the reference (1, 0.8, 0.1). */
 function formatNumber(v: number) {
@@ -43,7 +43,7 @@ function SelectPill({
         id={id}
         className={cn(
           PILL,
-          "w-full justify-between outline-none hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring/40",
+          "control-surface-interactive w-full justify-between outline-none hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring/40",
         )}
       >
         <span className="font-medium text-muted-foreground">{ctrl.label}</span>
@@ -148,7 +148,6 @@ function Control({
           max={ctrl.max}
           step={ctrl.step}
           formatValue={formatNumber}
-          className="[--elastic-slider-height:--spacing(11)] [--elastic-slider-radius:0.75rem] "
         />
       );
 
@@ -176,7 +175,10 @@ function Control({
       return (
         <label
           htmlFor={id}
-          className={cn(PILL, "cursor-pointer justify-between")}
+          className={cn(
+            PILL,
+            "control-surface-interactive cursor-pointer justify-between",
+          )}
         >
           <span className="font-medium text-muted-foreground">
             {ctrl.label}

--- a/components/docs/component-preview.tsx
+++ b/components/docs/component-preview.tsx
@@ -6,6 +6,12 @@ import { useQueryStates } from "nuqs";
 import { Suspense, use, useEffect, useMemo, useRef, useState } from "react";
 import { CodeBlock } from "@/components/docs/code-block";
 import { Button } from "@/components/ui/button";
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@/components/ui/frame";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTrackEvent } from "@/lib/analytics";
 import {
@@ -124,38 +130,41 @@ function Preview({
 
   return (
     <div className="not-prose mb-6 flex w-full flex-col gap-4">
-      <Tabs defaultValue="preview" className="gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <TabsList>
-            <TabsTrigger value="preview">Preview</TabsTrigger>
-            <TabsTrigger value="code">Code</TabsTrigger>
-          </TabsList>
-          {studioElement ? (
-            <StudioActions name={name} payload={studioElement} />
-          ) : null}
-        </div>
+      <Frame>
+        <Tabs defaultValue="preview" className="gap-0">
+          <FrameHeader className="flex-row items-center justify-between gap-3 px-2 py-2">
+            <TabsList>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+              <TabsTrigger value="code">Code</TabsTrigger>
+            </TabsList>
+            {studioElement ? (
+              <StudioActions name={name} payload={studioElement} />
+            ) : null}
+          </FrameHeader>
+          <FramePanel className="overflow-hidden p-0">
+            <TabsContent value="preview" className="mt-0">
+              <PreviewStage
+                name={name}
+                load={load}
+                inputProps={values}
+                durationInFrames={config.durationInFrames}
+                fps={config.fps}
+                compositionWidth={config.compositionWidth}
+                compositionHeight={config.compositionHeight}
+                previewBackdrop={config.previewBackdrop}
+                className="rounded-none"
+              />
+            </TabsContent>
+            <TabsContent value="code" className="mt-0">
+              <CodeBlock code={code} />
+            </TabsContent>
+          </FramePanel>
+        </Tabs>
+      </Frame>
 
-        <TabsContent value="preview" className="mt-0">
-          <PreviewStage
-            name={name}
-            load={load}
-            inputProps={values}
-            durationInFrames={config.durationInFrames}
-            fps={config.fps}
-            compositionWidth={config.compositionWidth}
-            compositionHeight={config.compositionHeight}
-            previewBackdrop={config.previewBackdrop}
-          />
-        </TabsContent>
-
-        <TabsContent value="code" className="mt-0">
-          <CodeBlock code={code} />
-        </TabsContent>
-      </Tabs>
-
-      <div className="overflow-hidden">
-        <div className="flex items-center justify-between pt-4 pb-2">
-          <span className="text-sm font-medium text-foreground">Customize</span>
+      <Frame className="mt-2">
+        <FrameHeader className="flex-row items-center justify-between px-3 py-2">
+          <FrameTitle>Customize</FrameTitle>
           <div className="flex items-center gap-1">
             <Button
               variant="outline"
@@ -183,13 +192,15 @@ function Preview({
               <RotateCcwIcon className="size-3.5" />
             </Button>
           </div>
-        </div>
-        <ComponentCustomizer
-          controls={config.controls}
-          values={values as Record<string, unknown>}
-          onChange={handleCustomizeChange}
-        />
-      </div>
+        </FrameHeader>
+        <FramePanel className="p-3">
+          <ComponentCustomizer
+            controls={config.controls}
+            values={values as Record<string, unknown>}
+            onChange={handleCustomizeChange}
+          />
+        </FramePanel>
+      </Frame>
     </div>
   );
 }

--- a/components/docs/docs-header.tsx
+++ b/components/docs/docs-header.tsx
@@ -9,36 +9,44 @@ import { NAV_LINKS } from "@/config/site";
  * Static, content-aligned header for the docs. Unlike `SiteHeader` it never
  * sticks, never listens to scroll, and never morphs into a pill.
  *
- * The inner container mirrors Fumadocs' centered docs layout
- * (`--fd-layout-width`) and the logo cell is the width of the sidebar column
- * (`--fd-sidebar-width`), so the logo sits over the sidebar, the nav begins
- * exactly at the article column's left edge, and the actions sit at the content
- * block's right edge. The CSS vars are redeclared here because this header
- * renders above (outside) DocsLayout, so its variables aren't in scope. The logo
- * cell keeps `px-4` at every breakpoint so the logo lands at 16px — flush with
- * the sidebar content's `p-4` and the tab labels below it (rather than hard
- * against the viewport edge once the grid fills the screen). `-ml-4` pulls the
- * first nav item's label flush with the article text while its ghost-button
- * background bleeds back into the gutter. The Components/Primitives switcher
- * lives in the thin `DocsTabsBar` rendered directly below this header.
+ * The inner container mirrors Fumadocs' docs grid cell for cell so the header
+ * chrome shares one vertical with the content below: the logo cell is the
+ * sidebar column (`--fd-sidebar-width`), the right actions cell is the TOC
+ * column (`--fd-toc-width`, xl+ only, like the rail itself), and the middle
+ * cell reproduces the page block between them — `max-w-[900px] mx-auto` with
+ * the page's own px-4/md:px-6/xl:px-8 — so the nav's first label starts on the
+ * article title's left edge at every viewport. Below xl the TOC cell is gone
+ * and the actions render inside the middle block, on the article's right edge.
+ * The CSS vars are redeclared here because this header renders above (outside)
+ * DocsLayout, so its variables aren't in scope. The logo cell keeps `px-4` at
+ * every breakpoint so the logo lands at 16px — flush with the sidebar content's
+ * `p-4` and the tab labels below it. `-ml-4` pulls the first nav item's label
+ * flush with the article text while its ghost-button background bleeds back
+ * into the gutter. The Components/Primitives switcher lives in the thin
+ * `DocsTabsBar` rendered directly below this header.
  *
- * The 97rem / 268px literals mirror fumadocs-ui 16.7 grid defaults — the docs
- * grid uses `var(--fd-layout-width, 97rem)` and `md:layout:[--fd-sidebar-width:268px]`
- * (the non-collapsible sidebar column equals the sidebar width). Matching the
- * grid's native 97rem (not a narrower 1400px) keeps the chrome and content in one
- * centered block so the logo sits over the sidebar. They must stay inline
- * (Tailwind JIT can't read JS constants); if a fumadocs upgrade changes those
- * defaults, re-sync the two values below.
+ * The 97rem / 268px / 900px literals mirror fumadocs-ui 16.7 grid defaults —
+ * `var(--fd-layout-width, 97rem)`, `md:layout:[--fd-sidebar-width:268px]`,
+ * `xl:layout:[--fd-toc-width:268px]`, and the page's `max-w-[900px]`. They must
+ * stay inline (Tailwind JIT can't read JS constants); if a fumadocs upgrade
+ * changes those defaults, re-sync the values below.
  */
 export function DocsHeader() {
   return (
     <header className="relative z-40 h-16 w-full border-b border-border bg-background/70 backdrop-blur-xl">
-      <div className="mx-auto flex h-16 w-full max-w-(--fd-layout-width) items-center [--fd-layout-width:97rem] md:[--fd-sidebar-width:268px]">
-        <div className="flex shrink-0 items-center px-4 md:w-(--fd-sidebar-width)">
+      <div className="mx-auto flex h-16 w-full max-w-(--fd-layout-width) items-center [--fd-layout-width:97rem] md:[--fd-sidebar-width:268px] xl:[--fd-toc-width:268px]">
+        <div className="flex shrink-0 items-center px-6 md:w-(--fd-sidebar-width)">
           <HeaderLogo />
         </div>
-        <div className="flex flex-1 items-center justify-between px-4 md:px-6 xl:px-5">
-          <NavDesktop links={NAV_LINKS} className="-ml-4" />
+        <div className="flex min-w-0 flex-1 items-center">
+          <div className="mx-auto flex w-full max-w-[900px] items-center justify-between px-4 md:px-6 xl:px-8">
+            <NavDesktop links={NAV_LINKS} className="-ml-4" />
+            <div className="xl:hidden">
+              <HeaderActions />
+            </div>
+          </div>
+        </div>
+        <div className="hidden shrink-0 items-center justify-end pe-4 xl:flex xl:w-(--fd-toc-width)">
           <HeaderActions />
         </div>
       </div>

--- a/components/docs/docs-sponsor.tsx
+++ b/components/docs/docs-sponsor.tsx
@@ -1,7 +1,12 @@
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import type React from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@/components/ui/frame";
 import { getDocsSponsors } from "@/config/sponsors";
 import { cn } from "@/lib/utils";
 
@@ -9,9 +14,9 @@ export const DocsSponsor: React.FC = () => {
   const featuredSponsors = getDocsSponsors();
 
   return (
-    <Card size="sm" className="w-full gap-4 shadow-2xs">
-      <CardHeader className="flex flex-row items-center justify-between gap-2">
-        <CardTitle>Sponsors</CardTitle>
+    <Frame className="w-full">
+      <FrameHeader className="flex-row items-center justify-between gap-2 px-3 py-2">
+        <FrameTitle className="text-sm">Sponsors</FrameTitle>
         <Link
           href="/sponsors"
           className="inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
@@ -19,9 +24,9 @@ export const DocsSponsor: React.FC = () => {
           Become a sponsor
           <ArrowUpRight className="size-3.5" aria-hidden="true" />
         </Link>
-      </CardHeader>
+      </FrameHeader>
 
-      <CardContent className="flex flex-col gap-1">
+      <FramePanel className="flex flex-col gap-1 p-2">
         {/* <span className="text-xs font-medium text-muted-foreground">Gold</span> */}
 
         {featuredSponsors.length > 0 ? (
@@ -32,7 +37,7 @@ export const DocsSponsor: React.FC = () => {
                 href={sponsor.website}
                 target="_blank"
                 rel="noreferrer"
-                className="group flex items-center justify-center gap-3 rounded-2xl surface-card px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                className="group flex items-center justify-center gap-3 rounded-md surface-card px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 {/** biome-ignore lint/performance/noImgElement: sponsor logos are SVGs of arbitrary sizes */}
                 <img
@@ -53,11 +58,11 @@ export const DocsSponsor: React.FC = () => {
             ))}
           </div>
         ) : (
-          <span className="rounded-2xl surface-card px-3 py-2.5 text-xs font-medium text-muted-foreground">
+          <span className="rounded-md surface-card px-3 py-2.5 text-xs font-medium text-muted-foreground">
             Your logo here
           </span>
         )}
-      </CardContent>
-    </Card>
+      </FramePanel>
+    </Frame>
   );
 };

--- a/components/docs/docs-tabs-bar.tsx
+++ b/components/docs/docs-tabs-bar.tsx
@@ -21,7 +21,7 @@ import { DocsTabs } from "@/components/docs/docs-tabs";
 export function DocsTabsBar() {
   return (
     <div className="sticky top-0 z-30 h-11 w-full border-b border-border bg-background/70 backdrop-blur-xl">
-      <div className="mx-auto flex h-11 w-full max-w-(--fd-layout-width) items-stretch px-4 [--fd-layout-width:97rem]">
+      <div className="mx-auto flex h-11 w-full max-w-(--fd-layout-width) items-stretch px-6 [--fd-layout-width:97rem]">
         <DocsTabs className="-ml-3" />
       </div>
     </div>

--- a/components/docs/install-all.tsx
+++ b/components/docs/install-all.tsx
@@ -1,16 +1,19 @@
+import { Frame, FramePanel } from "@/components/ui/frame";
 import { INSTALL_ALL_COMMAND } from "@/config/site";
 import { convertNpmCommand } from "@/lib/convert-npm-command";
 import { CodeBlockCommand } from "./code-block-command";
 
 export function InstallAll() {
   return (
-    <div className="my-6">
-      <CodeBlockCommand
-        component="all"
-        variant="outline"
-        prompt="Add every remocn component to my project."
-        {...convertNpmCommand(INSTALL_ALL_COMMAND)}
-      />
-    </div>
+    <Frame className="my-6">
+      <FramePanel className="overflow-hidden p-0">
+        <CodeBlockCommand
+          component="all"
+          variant="plain"
+          prompt="Add every remocn component to my project."
+          {...convertNpmCommand(INSTALL_ALL_COMMAND)}
+        />
+      </FramePanel>
+    </Frame>
   );
 }

--- a/components/docs/install-block.tsx
+++ b/components/docs/install-block.tsx
@@ -1,16 +1,27 @@
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@/components/ui/frame";
 import { convertNpmCommand } from "@/lib/convert-npm-command";
 import { CodeBlockCommand } from "./code-block-command";
 
 export function InstallBlock({ name }: { name: string }) {
   const npmCommand = `npx shadcn@latest add @remocn/${name}`;
   return (
-    <div className="my-6">
-      <CodeBlockCommand
-        component={name}
-        variant="outline"
-        prompt={`Add the @remocn/${name} component to my project.`}
-        {...convertNpmCommand(npmCommand)}
-      />
-    </div>
+    <Frame id="installation" className="my-6">
+      <FrameHeader className="flex-row items-center px-3 py-2.5">
+        <FrameTitle>Installation</FrameTitle>
+      </FrameHeader>
+      <FramePanel className="overflow-hidden p-0">
+        <CodeBlockCommand
+          component={name}
+          variant="plain"
+          prompt={`Add the @remocn/${name} component to my project.`}
+          {...convertNpmCommand(npmCommand)}
+        />
+      </FramePanel>
+    </Frame>
   );
 }

--- a/components/docs/props-table.tsx
+++ b/components/docs/props-table.tsx
@@ -1,3 +1,10 @@
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@/components/ui/frame";
+
 export interface PropDef {
   name: string;
   type: string;
@@ -6,77 +13,93 @@ export interface PropDef {
   description: string;
 }
 
-export function PropsTable({ rows }: { rows: PropDef[] }) {
+export function PropsTable({
+  rows,
+  title,
+}: {
+  rows: PropDef[];
+  title?: string;
+}) {
   return (
-    <div className="surface-card not-prose my-6 max-w-4xl overflow-hidden rounded-2xl">
-      <div
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: horizontally scrollable table must be keyboard-focusable
-        tabIndex={0}
-        className="overflow-x-auto"
-      >
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr className="border-b border-border/60">
-              <th className="px-4 py-2.5 text-left font-medium text-foreground">
-                Prop
-              </th>
-              <th className="px-4 py-2.5 text-left font-medium text-foreground">
-                Type
-              </th>
-              <th className="px-4 py-2.5 text-left font-medium text-foreground">
-                Default
-              </th>
-              <th className="px-4 py-2.5 text-left font-medium text-foreground">
-                Description
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row, i) => (
-              <tr
-                key={row.name}
-                className={
-                  i === rows.length - 1
-                    ? "align-top transition-colors hover:bg-background/40"
-                    : "border-b border-border/40 align-top transition-colors hover:bg-background/40"
-                }
-              >
-                <td className="px-4 py-3 align-top">
-                  <div className="flex items-center gap-1.5">
-                    <code className="font-mono text-xs text-foreground">
-                      {row.name}
+    <Frame
+      id={title ? title.toLowerCase() : undefined}
+      className="not-prose my-6 max-w-4xl"
+    >
+      {title && (
+        <FrameHeader className="flex-row items-center px-3 py-2.5">
+          <FrameTitle>{title}</FrameTitle>
+        </FrameHeader>
+      )}
+      <FramePanel className="overflow-hidden p-0">
+        <div
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: horizontally scrollable table must be keyboard-focusable
+          tabIndex={0}
+          className="overflow-x-auto"
+        >
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border/60">
+                <th className="px-4 py-2.5 text-left font-medium text-foreground">
+                  Prop
+                </th>
+                <th className="px-4 py-2.5 text-left font-medium text-foreground">
+                  Type
+                </th>
+                <th className="px-4 py-2.5 text-left font-medium text-foreground">
+                  Default
+                </th>
+                <th className="px-4 py-2.5 text-left font-medium text-foreground">
+                  Description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr
+                  key={row.name}
+                  className={
+                    i === rows.length - 1
+                      ? "align-top transition-colors hover:bg-muted/40"
+                      : "border-b border-border/40 align-top transition-colors hover:bg-muted/40"
+                  }
+                >
+                  <td className="px-4 py-3 align-top">
+                    <div className="flex items-center gap-1.5">
+                      <code className="font-mono text-xs text-foreground">
+                        {row.name}
+                      </code>
+                      {row.required && (
+                        <span className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-[10px] font-medium text-foreground/70">
+                          required
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    <code className="font-mono text-xs text-muted-foreground/90">
+                      {row.type}
                     </code>
-                    {row.required && (
-                      <span className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-[10px] font-medium text-foreground/70">
-                        required
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    {row.default ? (
+                      <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+                        {row.default}
+                      </code>
+                    ) : (
+                      <span className="font-mono text-xs text-muted-foreground/60">
+                        —
                       </span>
                     )}
-                  </div>
-                </td>
-                <td className="px-4 py-3 align-top">
-                  <code className="font-mono text-xs text-muted-foreground/90">
-                    {row.type}
-                  </code>
-                </td>
-                <td className="px-4 py-3 align-top">
-                  {row.default ? (
-                    <code className="rounded bg-background px-1.5 py-0.5 font-mono text-xs text-foreground">
-                      {row.default}
-                    </code>
-                  ) : (
-                    <span className="font-mono text-xs text-muted-foreground/60">
-                      —
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  {row.description}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {row.description}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </FramePanel>
+    </Frame>
   );
 }

--- a/components/docs/ui-component-preview.tsx
+++ b/components/docs/ui-component-preview.tsx
@@ -5,6 +5,12 @@ import { useQueryStates } from "nuqs";
 import { Suspense, use, useEffect, useMemo, useRef, useState } from "react";
 import { CodeBlock } from "@/components/docs/code-block";
 import { Button } from "@/components/ui/button";
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@/components/ui/frame";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTrackEvent } from "@/lib/analytics";
 import { type ControlConfig, getDefaults } from "@/lib/customizer-config";
@@ -144,38 +150,41 @@ function UiPreview({
 
   return (
     <div className="not-prose mb-6 flex w-full flex-col gap-4">
-      <Tabs defaultValue="preview" className="gap-3">
-        <TabsList>
-          <TabsTrigger value="preview">Preview</TabsTrigger>
-          <TabsTrigger value="code">Code</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="preview" className="mt-0">
-          <PreviewStage
-            name={name}
-            Component={scene.Scene}
-            inputProps={values}
-            // D2 — timing is sourced from the EXAMPLE, not the config.
-            durationInFrames={timing.durationInFrames}
-            fps={timing.fps}
-            compositionWidth={timing.width}
-            compositionHeight={timing.height}
-            previewBackdrop={timing.previewBackdrop}
-          />
-        </TabsContent>
-
-        <TabsContent value="code" className="mt-0">
-          <CodeBlock code={code} />
-        </TabsContent>
-      </Tabs>
+      <Frame>
+        <Tabs defaultValue="preview" className="gap-0">
+          <FrameHeader className="flex-row items-center px-2 py-2">
+            <TabsList>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+              <TabsTrigger value="code">Code</TabsTrigger>
+            </TabsList>
+          </FrameHeader>
+          <FramePanel className="overflow-hidden p-0">
+            <TabsContent value="preview" className="mt-0">
+              <PreviewStage
+                name={name}
+                Component={scene.Scene}
+                inputProps={values}
+                // D2 — timing is sourced from the EXAMPLE, not the config.
+                durationInFrames={timing.durationInFrames}
+                fps={timing.fps}
+                compositionWidth={timing.width}
+                compositionHeight={timing.height}
+                previewBackdrop={timing.previewBackdrop}
+                className="rounded-none"
+              />
+            </TabsContent>
+            <TabsContent value="code" className="mt-0">
+              <CodeBlock code={code} />
+            </TabsContent>
+          </FramePanel>
+        </Tabs>
+      </Frame>
 
       {/* Empty-panel collapse (Q5): no honored controls → only the Tabs. */}
       {hasControls && (
-        <div className="overflow-hidden ">
-          <div className="flex items-center justify-between pt-4 pb-2">
-            <span className="text-sm font-medium text-foreground">
-              Customize
-            </span>
+        <Frame className="mt-2">
+          <FrameHeader className="flex-row items-center justify-between px-3 py-2">
+            <FrameTitle>Customize</FrameTitle>
             <div className="flex items-center gap-1">
               <Button
                 variant="outline"
@@ -203,13 +212,15 @@ function UiPreview({
                 <RotateCcwIcon className="size-3.5" />
               </Button>
             </div>
-          </div>
-          <ComponentCustomizer
-            controls={visibleControls}
-            values={values as Record<string, unknown>}
-            onChange={handleCustomizeChange}
-          />
-        </div>
+          </FrameHeader>
+          <FramePanel className="p-3">
+            <ComponentCustomizer
+              controls={visibleControls}
+              values={values as Record<string, unknown>}
+              onChange={handleCustomizeChange}
+            />
+          </FramePanel>
+        </Frame>
       )}
     </div>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,16 +1,17 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
 
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-4xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-4xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px active:not-aria-[haspopup]:inset-shadow-[0_1px_2px_--theme(--color-black/8%)] dark:active:not-aria-[haspopup]:inset-shadow-[0_1px_2px_--theme(--color-black/25%)] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent dark:hover:bg-input/30",
+          "border-border bg-background shadow-xs/5 inset-shadow-[0_1px_0_--theme(--color-white/70%)] hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent dark:inset-shadow-[0_1px_0_--theme(--color-white/5%)] dark:hover:bg-input/30",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
@@ -42,14 +43,24 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  loading = false,
+  disabled,
+  children,
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: ButtonPrimitive.Props &
+  VariantProps<typeof buttonVariants> & { loading?: boolean }) {
   return (
     <ButtonPrimitive
       data-slot="button"
+      data-loading={loading || undefined}
+      aria-busy={loading || undefined}
+      disabled={disabled || loading}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
-    />
+    >
+      {loading && <Spinner />}
+      {children}
+    </ButtonPrimitive>
   );
 }
 

--- a/components/ui/elastic-slider.tsx
+++ b/components/ui/elastic-slider.tsx
@@ -474,7 +474,7 @@ export function ElasticSlider({
         aria-valuetext={displayValue}
         className={cn(
           "group/elastic-slider absolute inset-0 cursor-pointer touch-none overflow-hidden rounded-xl bg-(--elastic-slider-bg) outline-none select-none",
-          "data-[focus-visible=true]:ring-2 data-[focus-visible=true]:ring-ring/50 data-[focus-visible=true]:ring-offset-1 data-[focus-visible=true]:ring-offset-background bg-control",
+          "data-[focus-visible=true]:ring-2 data-[focus-visible=true]:ring-ring/50 data-[focus-visible=true]:ring-offset-1 data-[focus-visible=true]:ring-offset-background control-surface control-surface-interactive",
         )}
         style={{ width: rubberWidth, x: rubberX }}
         onPointerDown={handlePointerDown}

--- a/components/ui/frame.tsx
+++ b/components/ui/frame.tsx
@@ -1,0 +1,81 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Frame({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col rounded-2xl bg-muted/72 p-1 dark:bg-secondary",
+        "*:[[data-slot=frame-panel]+[data-slot=frame-panel]]:mt-1",
+        className,
+      )}
+      data-slot="frame"
+      {...props}
+    />
+  );
+}
+
+function FramePanel({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "relative rounded-xl border bg-background bg-clip-padding p-5 dark:border-border/60",
+        className,
+      )}
+      data-slot="frame-panel"
+      {...props}
+    />
+  );
+}
+
+function FrameHeader({ className, ...props }: React.ComponentProps<"header">) {
+  return (
+    <header
+      className={cn("flex flex-col px-5 py-4", className)}
+      data-slot="frame-panel-header"
+      {...props}
+    />
+  );
+}
+
+function FrameTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("font-heading font-semibold text-xl", className)}
+      data-slot="frame-panel-title"
+      {...props}
+    />
+  );
+}
+
+function FrameDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("text-muted-foreground text-sm", className)}
+      data-slot="frame-panel-description"
+      {...props}
+    />
+  );
+}
+
+function FrameFooter({ className, ...props }: React.ComponentProps<"footer">) {
+  return (
+    <footer
+      className={cn("px-5 py-4", className)}
+      data-slot="frame-panel-footer"
+      {...props}
+    />
+  );
+}
+
+export {
+  Frame,
+  FramePanel,
+  FrameHeader,
+  FrameTitle,
+  FrameDescription,
+  FrameFooter,
+};

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { NumberField as NumberFieldPrimitive } from "@base-ui/react/number-field";
+import { MinusIcon, PlusIcon } from "lucide-react";
+import * as React from "react";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+export const NumberFieldContext: React.Context<{
+  fieldId: string;
+} | null> = React.createContext<{
+  fieldId: string;
+} | null>(null);
+
+export function NumberField({
+  id,
+  className,
+  size = "default",
+  ...props
+}: NumberFieldPrimitive.Root.Props & {
+  size?: "sm" | "default" | "lg";
+}): React.ReactElement {
+  const generatedId = React.useId();
+  const fieldId = id ?? generatedId;
+
+  return (
+    <NumberFieldContext.Provider value={{ fieldId }}>
+      <NumberFieldPrimitive.Root
+        className={cn("flex w-full flex-col items-start gap-2", className)}
+        data-size={size}
+        data-slot="number-field"
+        id={fieldId}
+        {...props}
+      />
+    </NumberFieldContext.Provider>
+  );
+}
+
+export function NumberFieldGroup({
+  className,
+  ...props
+}: NumberFieldPrimitive.Group.Props): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Group
+      className={cn(
+        "relative flex w-full justify-between rounded-lg border border-input bg-background not-dark:bg-clip-padding text-base text-foreground shadow-xs/5 ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-data-disabled:not-focus-within:not-aria-invalid:before:shadow-[0_1px_--theme(--color-black/4%)] focus-within:border-ring focus-within:ring-[3px] has-aria-invalid:border-destructive/36 focus-within:has-aria-invalid:border-destructive/64 focus-within:has-aria-invalid:ring-destructive/16 data-disabled:pointer-events-none data-disabled:opacity-64 sm:text-sm dark:bg-input/32 dark:has-aria-invalid:ring-destructive/24 dark:not-data-disabled:not-focus-within:not-aria-invalid:before:shadow-[0_-1px_--theme(--color-white/6%)] [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [[data-disabled],:focus-within,[aria-invalid]]:shadow-none",
+        className,
+      )}
+      data-slot="number-field-group"
+      {...props}
+    />
+  );
+}
+
+export function NumberFieldDecrement({
+  className,
+  ...props
+}: NumberFieldPrimitive.Decrement.Props): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Decrement
+      className={cn(
+        "relative flex shrink-0 cursor-pointer items-center justify-center rounded-s-[calc(var(--radius-lg)-1px)] in-data-[size=sm]:px-[calc(--spacing(2.5)-1px)] px-[calc(--spacing(3)-1px)] transition-colors pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-accent",
+        className,
+      )}
+      data-slot="number-field-decrement"
+      {...props}
+    >
+      <MinusIcon />
+    </NumberFieldPrimitive.Decrement>
+  );
+}
+
+export function NumberFieldIncrement({
+  className,
+  ...props
+}: NumberFieldPrimitive.Increment.Props): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Increment
+      className={cn(
+        "relative flex shrink-0 cursor-pointer items-center justify-center rounded-e-[calc(var(--radius-lg)-1px)] in-data-[size=sm]:px-[calc(--spacing(2.5)-1px)] px-[calc(--spacing(3)-1px)] transition-colors pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-accent",
+        className,
+      )}
+      data-slot="number-field-increment"
+      {...props}
+    >
+      <PlusIcon />
+    </NumberFieldPrimitive.Increment>
+  );
+}
+
+export function NumberFieldInput({
+  className,
+  ...props
+}: NumberFieldPrimitive.Input.Props): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Input
+      className={cn(
+        "h-8.5 in-data-[size=lg]:h-9.5 in-data-[size=sm]:h-7.5 w-full min-w-0 grow bg-transparent in-data-[size=sm]:px-[calc(--spacing(2.5)-1px)] px-[calc(--spacing(3)-1px)] text-center text-foreground tabular-nums in-data-[size=lg]:leading-9.5 in-data-[size=sm]:leading-7.5 leading-8.5 outline-none sm:h-7.5 sm:in-data-[size=lg]:h-8.5 sm:in-data-[size=sm]:h-6.5 sm:in-data-[size=lg]:leading-8.5 sm:in-data-[size=sm]:leading-8.5 sm:leading-7.5",
+        className,
+      )}
+      data-slot="number-field-input"
+      {...props}
+    />
+  );
+}
+
+export function NumberFieldScrubArea({
+  className,
+  label,
+  ...props
+}: NumberFieldPrimitive.ScrubArea.Props & {
+  label: string;
+}): React.ReactElement {
+  const context = React.useContext(NumberFieldContext);
+
+  if (!context) {
+    throw new Error(
+      "NumberFieldScrubArea must be used within a NumberField component for accessibility.",
+    );
+  }
+
+  return (
+    <NumberFieldPrimitive.ScrubArea
+      className={cn("flex cursor-ew-resize", className)}
+      data-slot="number-field-scrub-area"
+      {...props}
+    >
+      <Label className="cursor-ew-resize" htmlFor={context.fieldId}>
+        {label}
+      </Label>
+      <NumberFieldPrimitive.ScrubAreaCursor className="drop-shadow-[0_1px_1px_#0008] filter">
+        <CursorGrowIcon />
+      </NumberFieldPrimitive.ScrubAreaCursor>
+    </NumberFieldPrimitive.ScrubArea>
+  );
+}
+
+export function CursorGrowIcon(
+  props: React.ComponentProps<"svg">,
+): React.ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="black"
+      height="14"
+      stroke="white"
+      viewBox="0 0 24 14"
+      width="26"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M19.5 5.5L6.49737 5.51844V2L1 6.9999L6.5 12L6.49737 8.5L19.5 8.5V12L25 6.9999L19.5 2V5.5Z" />
+    </svg>
+  );
+}
+
+export { NumberFieldPrimitive };

--- a/content/docs/ai/chat-gpt.mdx
+++ b/content/docs/ai/chat-gpt.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="chat-gpt" />
 
-## Installation
-
 <InstallBlock name="chat-gpt" />
 
 <Note>
@@ -74,9 +72,7 @@ import { ChatGpt } from "@/components/remocn/chat-gpt";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "greeting",

--- a/content/docs/ai/claude-chat.mdx
+++ b/content/docs/ai/claude-chat.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="claude-chat" />
 
-## Installation
-
 <InstallBlock name="claude-chat" />
 
 <Note>
@@ -89,9 +87,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "greeting",

--- a/content/docs/ai/claude-code.mdx
+++ b/content/docs/ai/claude-code.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="claude-code" />
 
-## Installation
-
 <InstallBlock name="claude-code" />
 
 <Note>
@@ -76,9 +74,7 @@ import { ClaudeCode } from "@/components/remocn/claude-code";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "title",

--- a/content/docs/ai/opencode.mdx
+++ b/content/docs/ai/opencode.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="opencode" />
 
-## Installation
-
 <InstallBlock name="opencode" />
 
 <Note>
@@ -75,9 +73,7 @@ import { OpenCode } from "@/components/remocn/opencode";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "placeholder",

--- a/content/docs/ai/v0.mdx
+++ b/content/docs/ai/v0.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="v0" />
 
-## Installation
-
 <InstallBlock name="v0" />
 
 <Note>
@@ -75,9 +73,7 @@ import { V0 } from "@/components/remocn/v0";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "greeting",

--- a/content/docs/compositions/ecosystem-constellation.mdx
+++ b/content/docs/compositions/ecosystem-constellation.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="ecosystem-constellation" />
 
-## Installation
-
 <InstallBlock name="ecosystem-constellation" />
 
 ## Usage
@@ -59,9 +57,7 @@ import { EcosystemConstellation } from "@/components/remocn/ecosystem-constellat
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "satelliteCount",

--- a/content/docs/compositions/infinite-bento-pan.mdx
+++ b/content/docs/compositions/infinite-bento-pan.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="infinite-bento-pan" />
 
-## Installation
-
 <InstallBlock name="infinite-bento-pan" />
 
 ## Usage
@@ -56,9 +54,7 @@ import { InfiniteBentoPan } from "@/components/remocn/infinite-bento-pan";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "panSpeed",

--- a/content/docs/compositions/live-code-compilation.mdx
+++ b/content/docs/compositions/live-code-compilation.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="live-code-compilation" />
 
-## Installation
-
 <InstallBlock name="live-code-compilation" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "accentColor",

--- a/content/docs/effects/confetti.mdx
+++ b/content/docs/effects/confetti.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="confetti" />
 
-## Installation
-
 <InstallBlock name="confetti" />
 
 ## Usage
@@ -53,9 +51,7 @@ export const RemotionRoot = () => (
 
 Every piece is generated from a seeded PRNG, so a given `seed` renders an identical burst on every machine — required for deterministic Remotion output and headless MP4 export. Particles launch radially from the origin, fall under `gravity`, and flutter as they spin.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "particleCount",

--- a/content/docs/effects/crumple-toss.mdx
+++ b/content/docs/effects/crumple-toss.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="crumple-toss" />
 
-## Installation
-
 <InstallBlock name="crumple-toss" />
 
 ## Usage
@@ -144,9 +142,7 @@ In absolute positioning — the intended use — that is invisible. In normal fl
 the element's box collapses on that frame, so wrap it in an `<AbsoluteFill>` or
 a sized container if the layout has to hold.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "children",

--- a/content/docs/effects/ink-arrow.mdx
+++ b/content/docs/effects/ink-arrow.mdx
@@ -14,8 +14,6 @@ avoidWhen:
 
 <ComponentPreview name="ink-arrow" />
 
-## Installation
-
 <InstallBlock name="ink-arrow" />
 
 ## Usage
@@ -66,9 +64,7 @@ to bow the other way. Each control point also carries a small per-`seed`
 wobble, which is what stops the curve looking machine-drawn; the same seed
 always gives the same hand.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "from",

--- a/content/docs/effects/paper-wobble.mdx
+++ b/content/docs/effects/paper-wobble.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="paper-wobble" />
 
-## Installation
-
 <InstallBlock name="paper-wobble" />
 
 ## Usage
@@ -70,9 +68,7 @@ The wrapper is `display: inline-block` and nothing else: no size, no
 background, no positioning. If you pass a `transform` through `style`, it is
 applied first and the jitter is appended, so your own positioning survives.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "children",

--- a/content/docs/effects/scribble-circle.mdx
+++ b/content/docs/effects/scribble-circle.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="scribble-circle" />
 
-## Installation
-
 <InstallBlock name="scribble-circle" />
 
 ## Usage
@@ -128,9 +126,7 @@ The root element keeps exactly the `width` and `height` you pass, so your
 positioning math stays predictable. Only the SVG overflows, by enough to cover
 the radius noise, the centre nudge, and the stroke.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "width",

--- a/content/docs/effects/simulated-cursor.mdx
+++ b/content/docs/effects/simulated-cursor.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="simulated-cursor" />
 
-## Installation
-
 <InstallBlock name="simulated-cursor" />
 
 ## Usage
@@ -88,9 +86,7 @@ const DemoScene = () => (
 Budget the `Sequence` from the waypoints: `24` frames per leg plus each point's `hold`. The default
 three-point path runs about `93` frames; leave headroom for the click ripple to finish.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "points",

--- a/content/docs/effects/tv-power-off.mdx
+++ b/content/docs/effects/tv-power-off.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="tv-power-off" />
 
 ## Usage
@@ -55,9 +53,7 @@ hangs long enough to read as a tube giving up rather than being switched.
 </TvPowerOff>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "durationInFrames",

--- a/content/docs/filters/components/ascii-render.mdx
+++ b/content/docs/filters/components/ascii-render.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="ascii-render" />
 
 ## Usage
@@ -149,9 +147,7 @@ instead, which keeps the scene recognisable while still reducing it to text.
 </AsciiRender>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "glyphSize",

--- a/content/docs/filters/components/camera-lens.mdx
+++ b/content/docs/filters/components/camera-lens.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="camera-lens" />
 
 ## Usage
@@ -95,9 +93,7 @@ Order matters. `Drift` goes inside so the scene moves behind stationary glass. P
 the lens inside the drift instead and you would be scaling the optics themselves,
 which is a lens breathing rather than a camera pushing in.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "softness",

--- a/content/docs/filters/components/crt-screen.mdx
+++ b/content/docs/filters/components/crt-screen.mdx
@@ -20,8 +20,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="crt-screen" />
 
 ## Usage
@@ -57,9 +55,7 @@ keeps the mask and scanlines.
 </CrtScreen>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "curvature",

--- a/content/docs/filters/components/halftone-print.mdx
+++ b/content/docs/filters/components/halftone-print.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="halftone-print" />
 
 ## Usage
@@ -128,9 +126,7 @@ deliberate one.
 Setting it to `0` gives a clean digital separation, which reads as a print
 simulation rather than as print.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "dotSize",

--- a/content/docs/filters/components/hologram.mdx
+++ b/content/docs/filters/components/hologram.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="hologram" />
 
 ## Usage
@@ -88,9 +86,7 @@ export const Opening = () => {
 To hand the shot back to reality afterwards, cut `intensity` to 0 — the scene
 returns exactly as it was, in one frame.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "tint",

--- a/content/docs/filters/components/pixelate-region.mdx
+++ b/content/docs/filters/components/pixelate-region.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="pixelate-region" />
 
 ## Usage
@@ -74,9 +72,7 @@ being readable well before it stops being recognisable, so err coarse: a cell
 around a third of the cap height of the text you are covering leaves nothing to
 reconstruct.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "regions",

--- a/content/docs/filters/components/security-cam.mdx
+++ b/content/docs/filters/components/security-cam.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="security-cam" />
 
 ## Usage
@@ -119,9 +117,7 @@ const block = interpolate(frame, [0, 36], [6, 26], {
 });
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "compression",

--- a/content/docs/filters/components/sustained-glitch.mdx
+++ b/content/docs/filters/components/sustained-glitch.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="sustained-glitch" />
 
 ## Usage
@@ -82,9 +80,7 @@ export const MyScene = () => {
 };
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "intensity",

--- a/content/docs/filters/components/underwater-ripple.mdx
+++ b/content/docs/filters/components/underwater-ripple.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="underwater-ripple" />
 
 ## Usage
@@ -106,9 +104,7 @@ export const Scene = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "amplitude",

--- a/content/docs/filters/components/vhs-filter.mdx
+++ b/content/docs/filters/components/vhs-filter.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 <CanvasFilterNote />
 
-## Installation
-
 <InstallBlock name="vhs-filter" />
 
 ## Usage
@@ -68,9 +66,7 @@ export const MyScene = () => {
 };
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "bleed",

--- a/content/docs/icons/gallery.mdx
+++ b/content/docs/icons/gallery.mdx
@@ -6,8 +6,6 @@ description: Browse every remocn icon, hover to play its motion, and copy the in
 
 Icon paths are derived from [Lucide](https://lucide.dev), licensed under the [ISC License](https://github.com/lucide-icons/lucide/blob/main/LICENSE), and re-authored from scratch for deterministic Remotion video.
 
-## Installation
-
 Install any icon by name — swap `icon-check` for the one you want from the gallery below.
 
 <InstallBlock name="icon-check" />

--- a/content/docs/layout/backdrop.mdx
+++ b/content/docs/layout/backdrop.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="backdrop" />
 
-## Installation
-
 <InstallBlock name="backdrop" />
 
 ## Usage
@@ -139,9 +137,7 @@ import { Backdrop } from "@/components/remocn/backdrop";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fill",

--- a/content/docs/layout/chat-to-preview-layout.mdx
+++ b/content/docs/layout/chat-to-preview-layout.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="chat-to-preview-layout" />
 
-## Installation
-
 <InstallBlock name="chat-to-preview-layout" />
 
 ## Usage
@@ -60,9 +58,7 @@ blocking out the timing before the real content exists.
   `0.2` on the standard `1280×720` canvas to stay clear of the clamp.
 </Note>
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "chat",

--- a/content/docs/layout/drift.mdx
+++ b/content/docs/layout/drift.mdx
@@ -14,8 +14,6 @@ avoidWhen:
 
 <ComponentPreview name="drift" />
 
-## Installation
-
 <InstallBlock name="drift" />
 
 ## Usage
@@ -80,9 +78,7 @@ A slow push-in keeps every glyph in sub-pixel motion, and a glyph raster can onl
 
 One layer per text container — never per word or character, and never on `Drift` itself. Keep borders and other hairline geometry outside the promoted layer: as part of a resampled texture, a 1px line pulses between sharp and blurry as the scale creeps, while fresh rasterization every frame lets it glide.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "grow",

--- a/content/docs/layout/stage.mdx
+++ b/content/docs/layout/stage.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="stage" />
 
-## Installation
-
 <InstallBlock name="stage" />
 
 ## Usage
@@ -139,9 +137,7 @@ The outer frame clips the surface. Targets near an edge, zoom below `1`, and str
 
 For an optical finish, wrap Stage in [`CameraLens`](/docs/filters/components/camera-lens). Stage supplies the physical set and operator path; CameraLens supplies bloom, softness, chromatic aberration, and vignette.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     { name: "children", type: "ReactNode", description: "The image, video, component, or scene rendered as one studio plane." },
     { name: "contentSize", type: "{ width: number; height: number }", default: "composition size", description: "Intrinsic surface dimensions used to preserve its aspect ratio, including long pages." },

--- a/content/docs/shaders/components/shader-caustics.mdx
+++ b/content/docs/shaders/components/shader-caustics.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-caustics" />
 
-## Installation
-
 <InstallBlock name="shader-caustics" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-color-panels.mdx
+++ b/content/docs/shaders/components/shader-color-panels.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-color-panels" />
 
-## Installation
-
 <InstallBlock name="shader-color-panels" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-dithering.mdx
+++ b/content/docs/shaders/components/shader-dithering.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-dithering" />
 
-## Installation
-
 <InstallBlock name="shader-dithering" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-dot-orbit.mdx
+++ b/content/docs/shaders/components/shader-dot-orbit.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-dot-orbit" />
 
-## Installation
-
 <InstallBlock name="shader-dot-orbit" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-gem-smoke.mdx
+++ b/content/docs/shaders/components/shader-gem-smoke.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-gem-smoke" />
 
-## Installation
-
 <InstallBlock name="shader-gem-smoke" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-god-rays.mdx
+++ b/content/docs/shaders/components/shader-god-rays.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-god-rays" />
 
-## Installation
-
 <InstallBlock name="shader-god-rays" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-grain-gradient.mdx
+++ b/content/docs/shaders/components/shader-grain-gradient.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-grain-gradient" />
 
-## Installation
-
 <InstallBlock name="shader-grain-gradient" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-liquid-metal.mdx
+++ b/content/docs/shaders/components/shader-liquid-metal.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-liquid-metal" />
 
-## Installation
-
 <InstallBlock name="shader-liquid-metal" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-mesh-gradient.mdx
+++ b/content/docs/shaders/components/shader-mesh-gradient.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-mesh-gradient" />
 
-## Installation
-
 <InstallBlock name="shader-mesh-gradient" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-metaballs.mdx
+++ b/content/docs/shaders/components/shader-metaballs.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-metaballs" />
 
-## Installation
-
 <InstallBlock name="shader-metaballs" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-neuro-noise.mdx
+++ b/content/docs/shaders/components/shader-neuro-noise.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-neuro-noise" />
 
-## Installation
-
 <InstallBlock name="shader-neuro-noise" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-perlin-noise.mdx
+++ b/content/docs/shaders/components/shader-perlin-noise.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-perlin-noise" />
 
-## Installation
-
 <InstallBlock name="shader-perlin-noise" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-pulsing-border.mdx
+++ b/content/docs/shaders/components/shader-pulsing-border.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-pulsing-border" />
 
-## Installation
-
 <InstallBlock name="shader-pulsing-border" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-simplex-noise.mdx
+++ b/content/docs/shaders/components/shader-simplex-noise.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-simplex-noise" />
 
-## Installation
-
 <InstallBlock name="shader-simplex-noise" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-smoke-ring.mdx
+++ b/content/docs/shaders/components/shader-smoke-ring.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-smoke-ring" />
 
-## Installation
-
 <InstallBlock name="shader-smoke-ring" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-spiral.mdx
+++ b/content/docs/shaders/components/shader-spiral.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-spiral" />
 
-## Installation
-
 <InstallBlock name="shader-spiral" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-strata.mdx
+++ b/content/docs/shaders/components/shader-strata.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-strata" />
 
-## Installation
-
 <InstallBlock name="shader-strata" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-swirl.mdx
+++ b/content/docs/shaders/components/shader-swirl.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-swirl" />
 
-## Installation
-
 <InstallBlock name="shader-swirl" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-voronoi.mdx
+++ b/content/docs/shaders/components/shader-voronoi.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-voronoi" />
 
-## Installation
-
 <InstallBlock name="shader-voronoi" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-warp.mdx
+++ b/content/docs/shaders/components/shader-warp.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-warp" />
 
-## Installation
-
 <InstallBlock name="shader-warp" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-water.mdx
+++ b/content/docs/shaders/components/shader-water.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-water" />
 
-## Installation
-
 <InstallBlock name="shader-water" />
 
 ## Usage

--- a/content/docs/shaders/components/shader-weave.mdx
+++ b/content/docs/shaders/components/shader-weave.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="shader-weave" />
 
-## Installation
-
 <InstallBlock name="shader-weave" />
 
 ## Usage

--- a/content/docs/social/github-sponsors.mdx
+++ b/content/docs/social/github-sponsors.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="github-sponsors" />
 
-## Installation
-
 <InstallBlock name="github-sponsors" />
 
 ## Usage
@@ -89,9 +87,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "account",

--- a/content/docs/social/github-stars.mdx
+++ b/content/docs/social/github-stars.mdx
@@ -20,8 +20,6 @@ avoidWhen:
   Want to see it with your own repo before installing? Head to [/stars](/stars), paste any GitHub repo URL, preview the animation, and download an MP4 — it's the live demo of this component.
 </Note>
 
-## Installation
-
 <InstallBlock name="github-stars" />
 
 ## Usage
@@ -99,9 +97,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "repo",

--- a/content/docs/social/logo-enter.mdx
+++ b/content/docs/social/logo-enter.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="logo-enter" />
 
-## Installation
-
 <InstallBlock name="logo-enter" />
 
 ## Usage
@@ -82,9 +80,7 @@ import { LogoEnter } from "@/components/remocn/logo-enter";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "logos",

--- a/content/docs/social/x-follow-card.mdx
+++ b/content/docs/social/x-follow-card.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="x-follow-card" />
 
-## Installation
-
 <InstallBlock name="x-follow-card" />
 
 <Note>
@@ -70,9 +68,7 @@ import { XFollowCard } from "@/components/remocn/x-follow-card";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "name",

--- a/content/docs/social/x-followers-overview.mdx
+++ b/content/docs/social/x-followers-overview.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="x-followers-overview" />
 
-## Installation
-
 <InstallBlock name="x-followers-overview" />
 
 <Note>
@@ -81,9 +79,7 @@ import { XFollowersOverview } from "@/components/remocn/x-followers-overview";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "notifications",

--- a/content/docs/transitions/ascii-dissolve.mdx
+++ b/content/docs/transitions/ascii-dissolve.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="ascii-dissolve" />
 
-## Installation
-
 <InstallBlock name="ascii-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/caret-wipe.mdx
+++ b/content/docs/transitions/caret-wipe.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="caret-wipe" />
 
-## Installation
-
 <InstallBlock name="caret-wipe" />
 
 ## Usage

--- a/content/docs/transitions/displacement.mdx
+++ b/content/docs/transitions/displacement.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasTransitionNote />
 
-## Installation
-
 <InstallBlock name="displacement" />
 
 ## Usage

--- a/content/docs/transitions/dither-dissolve.mdx
+++ b/content/docs/transitions/dither-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="dither-dissolve" />
 
-## Installation
-
 <InstallBlock name="dither-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/ember-burn.mdx
+++ b/content/docs/transitions/ember-burn.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasTransitionNote />
 
-## Installation
-
 <InstallBlock name="ember-burn" />
 
 ## Usage

--- a/content/docs/transitions/focus-pull.mdx
+++ b/content/docs/transitions/focus-pull.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="focus-pull" />
 
-## Installation
-
 <InstallBlock name="focus-pull" />
 
 ## Usage

--- a/content/docs/transitions/glitch-cut.mdx
+++ b/content/docs/transitions/glitch-cut.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasTransitionNote />
 
-## Installation
-
 <InstallBlock name="glitch-cut" />
 
 ## Usage

--- a/content/docs/transitions/grain-dissolve.mdx
+++ b/content/docs/transitions/grain-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="grain-dissolve" />
 
-## Installation
-
 <InstallBlock name="grain-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/grid-wave.mdx
+++ b/content/docs/transitions/grid-wave.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasTransitionNote />
 
-## Installation
-
 <InstallBlock name="grid-wave" />
 
 ## Usage

--- a/content/docs/transitions/icon-scatter.mdx
+++ b/content/docs/transitions/icon-scatter.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="icon-scatter" />
 
-## Installation
-
 <InstallBlock name="icon-scatter" />
 
 ## Usage

--- a/content/docs/transitions/lens-zoom.mdx
+++ b/content/docs/transitions/lens-zoom.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="lens-zoom" />
 
-## Installation
-
 <InstallBlock name="lens-zoom" />
 
 ## Usage

--- a/content/docs/transitions/page-turn.mdx
+++ b/content/docs/transitions/page-turn.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="page-turn" />
 
-## Installation
-
 <InstallBlock name="page-turn" />
 
 ## Usage
@@ -68,9 +66,7 @@ long each pose is held, but it cannot smooth the motion back out.
 Lower `poses` for a rougher, more obviously hand-made turn; raise it toward 16
 and the page starts to look mechanical.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "angle",

--- a/content/docs/transitions/particle-dissolve.mdx
+++ b/content/docs/transitions/particle-dissolve.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <CanvasTransitionNote />
 
-## Installation
-
 <InstallBlock name="particle-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/perlin-dissolve.mdx
+++ b/content/docs/transitions/perlin-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="perlin-dissolve" />
 
-## Installation
-
 <InstallBlock name="perlin-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/push-through.mdx
+++ b/content/docs/transitions/push-through.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="push-through" />
 
-## Installation
-
 <InstallBlock name="push-through" />
 
 ## Usage

--- a/content/docs/transitions/ripple-zoom.mdx
+++ b/content/docs/transitions/ripple-zoom.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="ripple-zoom" />
 
-## Installation
-
 <InstallBlock name="ripple-zoom" />
 
 ## Usage

--- a/content/docs/transitions/slide-swap.mdx
+++ b/content/docs/transitions/slide-swap.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="slide-swap" />
 
-## Installation
-
 <InstallBlock name="slide-swap" />
 
 ## Usage
@@ -84,9 +82,7 @@ const style =
 
 `slideInStyle` expects `e` to be `1` on the boundary frame, not `0` — the incoming scene is already moving on the frame it first appears.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "scenes",

--- a/content/docs/transitions/smoke-dissolve.mdx
+++ b/content/docs/transitions/smoke-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="smoke-dissolve" />
 
-## Installation
-
 <InstallBlock name="smoke-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/spring-settle.mdx
+++ b/content/docs/transitions/spring-settle.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="spring-settle" />
 
-## Installation
-
 <InstallBlock name="spring-settle" />
 
 ## Usage
@@ -107,9 +105,7 @@ This component installs `@remocn/scene-motion`, a small module of the curves sce
 
 The rule they encode: two properties of the same element never share a curve or a length. Opacity rides a short quad ramp, transform rides a long exponential or a damped spring roughly three times its length. That is the difference between "a slide faded in" and "something arrived".
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "scenes",

--- a/content/docs/transitions/swirl-dissolve.mdx
+++ b/content/docs/transitions/swirl-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="swirl-dissolve" />
 
-## Installation
-
 <InstallBlock name="swirl-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/warp-dissolve.mdx
+++ b/content/docs/transitions/warp-dissolve.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="warp-dissolve" />
 
-## Installation
-
 <InstallBlock name="warp-dissolve" />
 
 ## Usage

--- a/content/docs/transitions/wave-wipe.mdx
+++ b/content/docs/transitions/wave-wipe.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="wave-wipe" />
 
-## Installation
-
 <InstallBlock name="wave-wipe" />
 
 ## Usage

--- a/content/docs/transitions/whip-pan.mdx
+++ b/content/docs/transitions/whip-pan.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="whip-pan" />
 
-## Installation
-
 <InstallBlock name="whip-pan" />
 
 ## Usage

--- a/content/docs/transitions/zoom-blur.mdx
+++ b/content/docs/transitions/zoom-blur.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="zoom-blur" />
 
-## Installation
-
 <InstallBlock name="zoom-blur" />
 
 ## Usage

--- a/content/docs/typography/blur-out-up.mdx
+++ b/content/docs/typography/blur-out-up.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="blur-out-up" />
 
-## Installation
-
 <InstallBlock name="blur-out-up" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/bottom-up-letters.mdx
+++ b/content/docs/typography/bottom-up-letters.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="bottom-up-letters" />
 
-## Installation
-
 <InstallBlock name="bottom-up-letters" />
 
 ## Usage
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/caret-swap.mdx
+++ b/content/docs/typography/caret-swap.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="caret-swap" />
 
-## Installation
-
 <InstallBlock name="caret-swap" />
 
 ## Usage
@@ -82,9 +80,7 @@ export const RemotionRoot = () => (
 
 The exported `caretSwapLength(toText, swapAt, typeSpeed)` helper returns the frame on which the last character lands — use it as the lower bound of the `Sequence`, plus whatever hold you want for the blinking caret.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fromText",

--- a/content/docs/typography/centered-word-build.mdx
+++ b/content/docs/typography/centered-word-build.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="centered-word-build" />
 
-## Installation
-
 <InstallBlock name="centered-word-build" />
 
 ## Usage
@@ -82,9 +80,7 @@ export const RemotionRoot = () => (
 
 With the defaults, a four-word phrase reveals on frames 0, 11, 22, and 30, reaching cumulative scales of 1, 1.035, 1.07, and 1.105. The exported `centeredWordBuildLength(text, wordGap, accel, settleFrames, exitAt, exitFrames)` helper returns the frame on which all motion finishes.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/chromatic-wave.mdx
+++ b/content/docs/typography/chromatic-wave.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="chromatic-wave" />
 
-## Installation
-
 <InstallBlock name="chromatic-wave" />
 
 ## Usage
@@ -50,9 +48,7 @@ depths pull them apart, red, green and blue fringes appear. The component
 paints its own `background` (default black) because the reassembly is only
 exact over black.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "headline",

--- a/content/docs/typography/extrude-pop.mdx
+++ b/content/docs/typography/extrude-pop.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="extrude-pop" />
 
-## Installation
-
 <InstallBlock name="extrude-pop" />
 
 ## Usage
@@ -48,9 +46,7 @@ dilation drawn as stacked copies, back-to-front, with the white face riding the
 near end. Face travel and extrusion depth are keyframed together, which is what
 makes the word read as lifting off a plane rather than growing a shadow.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "letter",

--- a/content/docs/typography/fade-through.mdx
+++ b/content/docs/typography/fade-through.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="fade-through" />
 
-## Installation
-
 <InstallBlock name="fade-through" />
 
 ## Usage
@@ -90,9 +88,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fromText",

--- a/content/docs/typography/focus-blur-resolve.mdx
+++ b/content/docs/typography/focus-blur-resolve.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="focus-blur-resolve" />
 
-## Installation
-
 <InstallBlock name="focus-blur-resolve" />
 
 ## Usage
@@ -75,9 +73,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/fog-rise.mdx
+++ b/content/docs/typography/fog-rise.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="fog-rise" />
 
-## Installation
-
 <InstallBlock name="fog-rise" />
 
 ## Usage
@@ -75,9 +73,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/gooey-morph.mdx
+++ b/content/docs/typography/gooey-morph.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="gooey-morph" />
 
-## Installation
-
 <InstallBlock name="gooey-morph" />
 
 ## Usage
@@ -50,9 +48,7 @@ cross the threshold, and paint a solid neck between them. Everything that
 should fuse lives inside the component's single filtered group — nearby
 elements outside it never join the goo.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "word",

--- a/content/docs/typography/gradient-scale-cut-text.mdx
+++ b/content/docs/typography/gradient-scale-cut-text.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="gradient-scale-cut-text" />
 
-## Installation
-
 <InstallBlock name="gradient-scale-cut-text" />
 
 ## Usage
@@ -75,9 +73,7 @@ restart after the cut. `settleTravel` controls the compact entrance distance,
 />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/hand-count.mdx
+++ b/content/docs/typography/hand-count.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="hand-count" />
 
-## Installation
-
 <InstallBlock name="hand-count" />
 
 ## Usage
@@ -118,9 +116,7 @@ freezes the moment it does. A headline number that keeps twitching for the rest
 of the shot is a distraction, not a texture; ambient motion in this kit is
 `paper-wobble`'s job.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "to",

--- a/content/docs/typography/handwrite.mdx
+++ b/content/docs/typography/handwrite.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="handwrite" />
 
-## Installation
-
 <InstallBlock name="handwrite" />
 
 ## Usage
@@ -74,9 +72,7 @@ frames per pose is ten poses a second at 30fps. Raise it for a slower, more
 deliberate hand. The component holds still between poses — wrap it in
 `paper-wobble` if the whole sheet should breathe.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/infinite-marquee.mdx
+++ b/content/docs/typography/infinite-marquee.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="infinite-marquee" />
 
-## Installation
-
 <InstallBlock name="infinite-marquee" />
 
 ## Usage
@@ -56,9 +54,7 @@ import { InfiniteMarquee } from "@/components/remocn/infinite-marquee";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/ink-underline.mdx
+++ b/content/docs/typography/ink-underline.mdx
@@ -14,8 +14,6 @@ avoidWhen:
 
 <ComponentPreview name="ink-underline" />
 
-## Installation
-
 <InstallBlock name="ink-underline" />
 
 ## Usage
@@ -70,9 +68,7 @@ curve, and changing it gives a different hand. `durationSteps` is how many
 stop-motion poses the drag takes, so the real length in frames is
 `durationSteps * step`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "width",

--- a/content/docs/typography/inline-highlight.mdx
+++ b/content/docs/typography/inline-highlight.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="inline-highlight" />
 
-## Installation
-
 <InstallBlock name="inline-highlight" />
 
 ## Usage
@@ -48,9 +46,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "before",

--- a/content/docs/typography/inline-pill-takeover.mdx
+++ b/content/docs/typography/inline-pill-takeover.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="inline-pill-takeover" />
 
-## Installation
-
 <InstallBlock name="inline-pill-takeover" />
 
 ## Usage
@@ -86,9 +84,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "before",

--- a/content/docs/typography/kinetic-center-build.mdx
+++ b/content/docs/typography/kinetic-center-build.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="kinetic-center-build" />
 
-## Installation
-
 <InstallBlock name="kinetic-center-build" />
 
 ## Usage
@@ -76,9 +74,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/kinetic-warp.mdx
+++ b/content/docs/typography/kinetic-warp.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="kinetic-warp" />
 
-## Installation
-
 <InstallBlock name="kinetic-warp" />
 
 ## Usage
@@ -49,9 +47,7 @@ export const RemotionRoot = () => (
 
 The component renders to a canvas, so the font must actually be loaded before the text is drawn — pass `fontUrl` for any webfont and the render is held (via `delayRender`) until it lands.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/line-by-line-slide.mdx
+++ b/content/docs/typography/line-by-line-slide.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="line-by-line-slide" />
 
-## Installation
-
 <InstallBlock name="line-by-line-slide" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/marker-highlight.mdx
+++ b/content/docs/typography/marker-highlight.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="marker-highlight" />
 
-## Installation
-
 <InstallBlock name="marker-highlight" />
 
 ## Usage
@@ -48,9 +46,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "before",

--- a/content/docs/typography/mask-reveal-up.mdx
+++ b/content/docs/typography/mask-reveal-up.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="mask-reveal-up" />
 
-## Installation
-
 <InstallBlock name="mask-reveal-up" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/matrix-decode.mdx
+++ b/content/docs/typography/matrix-decode.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="matrix-decode" />
 
-## Installation
-
 <InstallBlock name="matrix-decode" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/micro-scale-fade.mdx
+++ b/content/docs/typography/micro-scale-fade.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="micro-scale-fade" />
 
-## Installation
-
 <InstallBlock name="micro-scale-fade" />
 
 ## Usage
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/number-wheel.mdx
+++ b/content/docs/typography/number-wheel.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="number-wheel" />
 
-## Installation
-
 <InstallBlock name="number-wheel" />
 
 ## Usage
@@ -44,9 +42,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "from",

--- a/content/docs/typography/outline-fill-track-text.mdx
+++ b/content/docs/typography/outline-fill-track-text.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="outline-fill-track-text" />
 
-## Installation
-
 <InstallBlock name="outline-fill-track-text" />
 
 ## Usage
@@ -83,9 +81,7 @@ from rest, carries speed through the middle, and decelerates into the hold.
 />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "leadText",

--- a/content/docs/typography/per-character-rise.mdx
+++ b/content/docs/typography/per-character-rise.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="per-character-rise" />
 
-## Installation
-
 <InstallBlock name="per-character-rise" />
 
 ## Usage
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/per-word-crossfade.mdx
+++ b/content/docs/typography/per-word-crossfade.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="per-word-crossfade" />
 
-## Installation
-
 <InstallBlock name="per-word-crossfade" />
 
 ## Usage
@@ -90,9 +88,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fromText",

--- a/content/docs/typography/perspective-marquee.mdx
+++ b/content/docs/typography/perspective-marquee.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="perspective-marquee" />
 
-## Installation
-
 <InstallBlock name="perspective-marquee" />
 
 ## Usage
@@ -60,9 +58,7 @@ import { PerspectiveMarquee } from "@/components/remocn/perspective-marquee";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "items",

--- a/content/docs/typography/perspective-squeeze.mdx
+++ b/content/docs/typography/perspective-squeeze.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="perspective-squeeze" />
 
-## Installation
-
 <InstallBlock name="perspective-squeeze" />
 
 ## Usage
@@ -55,9 +53,7 @@ the gap between the lines never changes. The perspective is a true projective
 corner-pin (`matrix3d`), interpolated on the corners, so straight lines stay
 straight while parallels converge.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "upperText / lowerText",

--- a/content/docs/typography/rgb-glitch-text.mdx
+++ b/content/docs/typography/rgb-glitch-text.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="rgb-glitch-text" />
 
-## Installation
-
 <InstallBlock name="rgb-glitch-text" />
 
 ## Usage
@@ -44,9 +42,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/rolling-number.mdx
+++ b/content/docs/typography/rolling-number.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="rolling-number" />
 
-## Installation
-
 <InstallBlock name="rolling-number" />
 
 ## Usage
@@ -44,9 +42,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "from",

--- a/content/docs/typography/rolodex-flip.mdx
+++ b/content/docs/typography/rolodex-flip.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="rolodex-flip" />
 
-## Installation
-
 <InstallBlock name="rolodex-flip" />
 
 ## Usage
@@ -40,9 +38,7 @@ The sizer uses the longest item by character count as real hidden text, so it wo
 
 `slot-machine-roll` and `number-wheel` are numeric reels, `per-word-crossfade` is a flat opacity swap, and `value-swap` slides values vertically at explicit frames — reach for `RolodexFlip` when arbitrary strings should cycle with physical depth at a fixed width.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "items",

--- a/content/docs/typography/rush-type.mdx
+++ b/content/docs/typography/rush-type.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="rush-type" />
 
-## Installation
-
 <InstallBlock name="rush-type" />
 
 ## Usage
@@ -80,9 +78,7 @@ shutters to show.
 />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "phrase",

--- a/content/docs/typography/scale-down-fade.mdx
+++ b/content/docs/typography/scale-down-fade.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="scale-down-fade" />
 
-## Installation
-
 <InstallBlock name="scale-down-fade" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/shadow-sweep-text.mdx
+++ b/content/docs/typography/shadow-sweep-text.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shadow-sweep-text" />
 
-## Installation
-
 <InstallBlock name="shadow-sweep-text" />
 
 ## Usage
@@ -75,9 +73,7 @@ covered.
 />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/shared-axis-y.mdx
+++ b/content/docs/typography/shared-axis-y.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shared-axis-y" />
 
-## Installation
-
 <InstallBlock name="shared-axis-y" />
 
 ## Usage
@@ -90,9 +88,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fromText",

--- a/content/docs/typography/shared-axis-z.mdx
+++ b/content/docs/typography/shared-axis-z.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shared-axis-z" />
 
-## Installation
-
 <InstallBlock name="shared-axis-z" />
 
 ## Usage
@@ -90,9 +88,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "fromText",

--- a/content/docs/typography/sheen-slide-in.mdx
+++ b/content/docs/typography/sheen-slide-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="sheen-slide-in" />
 
-## Installation
-
 <InstallBlock name="sheen-slide-in" />
 
 ## Usage
@@ -70,9 +68,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/shimmer-sweep.mdx
+++ b/content/docs/typography/shimmer-sweep.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="shimmer-sweep" />
 
-## Installation
-
 <InstallBlock name="shimmer-sweep" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/short-slide-down.mdx
+++ b/content/docs/typography/short-slide-down.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="short-slide-down" />
 
-## Installation
-
 <InstallBlock name="short-slide-down" />
 
 ## Usage
@@ -76,9 +74,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/short-slide-right.mdx
+++ b/content/docs/typography/short-slide-right.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="short-slide-right" />
 
-## Installation
-
 <InstallBlock name="short-slide-right" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/slot-machine-roll.mdx
+++ b/content/docs/typography/slot-machine-roll.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="slot-machine-roll" />
 
-## Installation
-
 <InstallBlock name="slot-machine-roll" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "from",

--- a/content/docs/typography/soft-blur-in.mdx
+++ b/content/docs/typography/soft-blur-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="soft-blur-in" />
 
-## Installation
-
 <InstallBlock name="soft-blur-in" />
 
 ## Usage
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/spring-scale-in.mdx
+++ b/content/docs/typography/spring-scale-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="spring-scale-in" />
 
-## Installation
-
 <InstallBlock name="spring-scale-in" />
 
 ## Usage
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/squeeze-in.mdx
+++ b/content/docs/typography/squeeze-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="squeeze-in" />
 
-## Installation
-
 <InstallBlock name="squeeze-in" />
 
 ## Usage
@@ -70,9 +68,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/staggered-fade-up.mdx
+++ b/content/docs/typography/staggered-fade-up.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="staggered-fade-up" />
 
-## Installation
-
 <InstallBlock name="staggered-fade-up" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/stretch-in.mdx
+++ b/content/docs/typography/stretch-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="stretch-in" />
 
-## Installation
-
 <InstallBlock name="stretch-in" />
 
 ## Usage
@@ -52,9 +50,7 @@ in P, O, R) go through the same deformation, so they never detach.
 out of the box; point it at any `.ttf`/`.otf` URL to change the face. The
 render is held until the font file has loaded.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/strikethrough-replace.mdx
+++ b/content/docs/typography/strikethrough-replace.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="strikethrough-replace" />
 
-## Installation
-
 <InstallBlock name="strikethrough-replace" />
 
 ## Usage
@@ -65,9 +63,7 @@ const StrikethroughScene = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "from",

--- a/content/docs/typography/top-down-letters.mdx
+++ b/content/docs/typography/top-down-letters.mdx
@@ -17,8 +17,6 @@ avoidWhen:
 
 <ComponentPreview name="top-down-letters" />
 
-## Installation
-
 <InstallBlock name="top-down-letters" />
 
 ## Usage
@@ -73,9 +71,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/tracking-in.mdx
+++ b/content/docs/typography/tracking-in.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="tracking-in" />
 
-## Installation
-
 <InstallBlock name="tracking-in" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/typed-split-wipe.mdx
+++ b/content/docs/typography/typed-split-wipe.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="typed-split-wipe" />
 
-## Installation
-
 <InstallBlock name="typed-split-wipe" />
 
 ## Usage
@@ -80,9 +78,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "prefix",

--- a/content/docs/typography/typewriter.mdx
+++ b/content/docs/typography/typewriter.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="typewriter" />
 
-## Installation
-
 <InstallBlock name="typewriter" />
 
 ## Usage
@@ -43,9 +41,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/value-swap.mdx
+++ b/content/docs/typography/value-swap.mdx
@@ -14,8 +14,6 @@ avoidWhen:
 
 <ComponentPreview name="value-swap" />
 
-## Installation
-
 <InstallBlock name="value-swap" />
 
 ## Usage
@@ -42,9 +40,7 @@ A tight before/after pair reads best with a snappier swap — try `duration={9} 
 
 `rolodex-flip` is a 3D card flip with its own rhythm (`interval`) — reach for it when values cycle as a montage; `ValueSwap` is a flat vertical slide at explicit frames — reach for it for a point change (before → after, a status or price flip); `rolling-number` animates numeric digits individually.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "values",

--- a/content/docs/typography/word-push.mdx
+++ b/content/docs/typography/word-push.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="word-push" />
 
-## Installation
-
 <InstallBlock name="word-push" />
 
 ## Usage
@@ -74,9 +72,7 @@ export const RemotionRoot = () => (
 
 `wordGap` sets the first gap and `accel` shrinks every following one, so the build accelerates as one gesture rather than per word. The exported `wordPushLength(text, wordGap)` helper returns the frame on which the last push settles — use it as the lower bound of the `Sequence`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/word-stream.mdx
+++ b/content/docs/typography/word-stream.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="word-stream" />
 
-## Installation
-
 <InstallBlock name="word-stream" />
 
 ## Usage
@@ -79,9 +77,7 @@ export const RemotionRoot = () => (
 
 `wordGap` is the number of frames between word reveals — match it to the speaking pace of the narration (at 30fps, `wordGap={6}` is 5 words per second). `hold` controls how long a finished phrase stays before the next one starts. The exported `wordStreamLength(text, wordGap, hold)` helper returns the frame on which the last word finishes resolving — use it as the lower bound of the `Sequence`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/typography/zoom-words.mdx
+++ b/content/docs/typography/zoom-words.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="zoom-words" />
 
-## Installation
-
 <InstallBlock name="zoom-words" />
 
 ## Usage
@@ -81,9 +79,7 @@ export const RemotionRoot = () => (
 
 The exported `zoomWordsLength(text, wordGap)` helper returns the frame on which the camera settles after the last word — cut to the next scene at or shortly after it.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "text",

--- a/content/docs/ui-blocks/animated-bar-chart.mdx
+++ b/content/docs/ui-blocks/animated-bar-chart.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="animated-bar-chart" />
 
-## Installation
-
 <InstallBlock name="animated-bar-chart" />
 
 ## Usage
@@ -58,9 +56,7 @@ import { AnimatedBarChart } from "@/components/remocn/animated-bar-chart";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "data",

--- a/content/docs/ui-blocks/animated-line-chart.mdx
+++ b/content/docs/ui-blocks/animated-line-chart.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="animated-line-chart" />
 
-## Installation
-
 <InstallBlock name="animated-line-chart" />
 
 ## Usage
@@ -58,9 +56,7 @@ import { AnimatedLineChart } from "@/components/remocn/animated-line-chart";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "data",

--- a/content/docs/ui-blocks/check-list.mdx
+++ b/content/docs/ui-blocks/check-list.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="check-list" />
 
-## Installation
-
 <InstallBlock name="check-list" />
 
 ## Usage
@@ -119,9 +117,7 @@ the list takes its width explicitly and derives every label cell, box offset,
 and row from it. The component sets no background and no jitter of its own —
 wrap it in `paper-wobble` to put it on the desk.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "items",

--- a/content/docs/ui-blocks/glass-code-block.mdx
+++ b/content/docs/ui-blocks/glass-code-block.mdx
@@ -14,8 +14,6 @@ avoidWhen:
 
 <ComponentPreview name="glass-code-block" />
 
-## Installation
-
 <InstallBlock name="glass-code-block" />
 
 ## Usage
@@ -57,9 +55,7 @@ import { GlassCodeBlock } from "@/components/remocn/glass-code-block";
 </Backdrop>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "code",

--- a/content/docs/ui-blocks/glass-code-walk.mdx
+++ b/content/docs/ui-blocks/glass-code-walk.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="glass-code-walk" />
 
-## Installation
-
 <InstallBlock name="glass-code-walk" />
 
 ## Usage
@@ -48,9 +46,7 @@ export const RemotionRoot = () => (
 
 The camera mirrors `glass-code-block`'s line layout to keep the revealing line pinned, so it pairs with that component — `npx shadcn add @remocn/glass-code-walk` pulls it in automatically. Renders transparent; supply the background with `Backdrop` so the glass has an image to refract.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "code",

--- a/content/docs/ui-blocks/paper-sticker.mdx
+++ b/content/docs/ui-blocks/paper-sticker.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="paper-sticker" />
 
-## Installation
-
 <InstallBlock name="paper-sticker" />
 
 ## Usage
@@ -79,9 +77,7 @@ removes the fixed tilt for a deliberately tidy row; the chip still carries the
 per-pose wobble of roughly a fifth of a degree, because it is still a piece of
 paper on a desk.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "children",

--- a/content/docs/ui-blocks/polaroid.mdx
+++ b/content/docs/ui-blocks/polaroid.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="polaroid" />
 
-## Installation
-
 <InstallBlock name="polaroid" />
 
 ## Usage
@@ -97,9 +95,7 @@ Every measurement derives from `width`, so the card keeps the proportions of
 the original 652px print at any size. `captionSize` defaults to the same scale;
 pass it explicitly only when you want the caption off that ratio.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "children",

--- a/content/docs/ui-blocks/reel.mdx
+++ b/content/docs/ui-blocks/reel.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="reel" />
 
-## Installation
-
 <InstallBlock name="reel" />
 
 ## Usage
@@ -55,9 +53,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "images",

--- a/content/docs/ui-blocks/terminal-cursor-zoom.mdx
+++ b/content/docs/ui-blocks/terminal-cursor-zoom.mdx
@@ -16,8 +16,6 @@ avoidWhen:
 
 <ComponentPreview name="terminal-cursor-zoom" />
 
-## Installation
-
 <InstallBlock name="terminal-cursor-zoom" />
 
 ## Usage
@@ -45,9 +43,7 @@ export const RemotionRoot = () => (
 
 The camera reads `terminal-simulator`'s fixed layout to keep the cursor pinned, so it pairs with that component — `npx shadcn add @remocn/terminal-cursor-zoom` pulls it in automatically.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "command",

--- a/content/docs/ui-blocks/terminal-simulator.mdx
+++ b/content/docs/ui-blocks/terminal-simulator.mdx
@@ -15,8 +15,6 @@ avoidWhen:
 
 <ComponentPreview name="terminal-simulator" />
 
-## Installation
-
 <InstallBlock name="terminal-simulator" />
 
 ## Usage
@@ -47,9 +45,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "lines",

--- a/content/docs/ui/blocks/ai-prompt-flow.mdx
+++ b/content/docs/ui/blocks/ai-prompt-flow.mdx
@@ -22,8 +22,6 @@ response, then crossfades into the generated answer, and a ready toast slides in
 orchestrator — every channel comes from a composed primitive's transition hook, so nothing is
 hand-timed.
 
-## Installation
-
 <InstallBlock name="ai-prompt-flow" />
 
 <Note>
@@ -72,9 +70,7 @@ export const RemotionRoot = () => (
 );
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "prompt",

--- a/content/docs/ui/blocks/chat-flow.mdx
+++ b/content/docs/ui/blocks/chat-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A composition scene that renders a full chat conversation — a contact header, a message thread, and a composer input. Outgoing messages type themselves into the input field then send; incoming replies are preceded by a typing indicator that swaps to the reply bubble; reaction emojis pop in after each reply lands.
 
-## Installation
-
 <InstallBlock name="chat-flow" />
 
 <Note>
@@ -38,9 +36,7 @@ The layout is a mobile-width column — a contact header, the message thread, an
 
 The scene opens with the composer focused. The first outgoing message ("Hey — ready for the demo?") types into the input, then sends — the bubble enters from below and settles into the thread. The contact's typing indicator appears inside an incoming bubble; after a beat the indicator swaps to the reply text ("Yep, pushing it live now") and the 🔥 reaction badge pops in. The second outgoing message types and sends ("Perfect, sending the link over"), and its 👍 reaction badge follows. `chatFlowDuration` returns the total frame count for the default script at a given speed; `chatFlowSchedule` exposes the per-message frame offsets for synchronisation with other scene elements.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "messages",

--- a/content/docs/ui/blocks/checkout-flow.mdx
+++ b/content/docs/ui/blocks/checkout-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A composition scene rendered as a real checkout card. The card and its fields blur-in in sequence, then a cursor flips the billing toggle monthly → yearly, types the card number, ticks the terms checkbox, and presses Pay through loading to success — finishing with a success toast. A pure orchestrator: every animated channel comes from a composed primitive's transition hook.
 
-## Installation
-
 <InstallBlock name="checkout-flow" />
 
 <Note>
@@ -41,9 +39,7 @@ Installing `checkout-flow` automatically installs the shared `remocn-ui` core an
 
 The card surface fades in place (frames 0–18), then the header and each field blur-in staggered, all settling by frame 58. At frame 64 the cursor clicks the Yearly segment and the toggle thumb slides to it. At frame 96 the cursor focuses the card-number field, which types in from frame 100 to 140, then settles to its static filled state as the cursor leaves at 150 — the same frame the terms checkbox is clicked and ticks. At frame 180 the cursor presses Pay: hover → press → loading (186) → success (224). The success toast slides in at frame 224 and auto-dismisses at frame 286.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "title",

--- a/content/docs/ui/blocks/imessage-chat-flow.mdx
+++ b/content/docs/ui/blocks/imessage-chat-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 An iMessage-skinned composition scene — a tailed-bubble message thread, a native-feeling composer bar, and a contact header with FaceTime video icon. Outgoing messages type into the composer then send as blue tailed bubbles with a "Delivered" label underneath; incoming replies are preceded by a gray typing bubble (three bouncing dots) that swaps to the reply text; tapback reaction badges pop in at the top outer corner of their parent bubble.
 
-## Installation
-
 <InstallBlock name="imessage-chat-flow" />
 
 <Note>
@@ -37,9 +35,7 @@ The block is otherwise self-contained: it owns its tailed bubble layout (gray `#
 
 The scene opens with a focused iMessage composer. The first outgoing message types into the input field, then sends — a blue tailed bubble enters from below and settles into the thread with a "Delivered" label underneath. A gray typing bubble with three bouncing dots appears on the incoming side; after a beat the dots swap to the reply text and the tapback reaction badge pops in at the top outer corner. Subsequent outgoing messages follow the same pattern — typing, sending, Delivered — each reply preceded by the typing bubble. The composer returns to idle at the end.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "messages",

--- a/content/docs/ui/blocks/onboarding-stepper-flow.mdx
+++ b/content/docs/ui/blocks/onboarding-stepper-flow.mdx
@@ -21,8 +21,6 @@ advances across panels of input, radio, and switch fields, finishing on a Finish
 success. The panel crossfade derives linearly from the stepper's exposed position channel; every
 other channel comes from a composed primitive's hook.
 
-## Installation
-
 <InstallBlock name="onboarding-stepper-flow" />
 
 <Note>
@@ -77,9 +75,7 @@ export const RemotionRoot = () => (
   with your own panels directly.
 </Note>
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "steps",

--- a/content/docs/ui/blocks/settings-toggle-flow.mdx
+++ b/content/docs/ui/blocks/settings-toggle-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A composition scene laid out as a centered two-column settings card: a descriptive text block on the left, the controls stacked on the right — each under its own label, including a "Volume" label for the slider. The card and its controls blur-in in sequence, then a cursor flips the notifications switch, opens the theme select and picks an option, drags the volume slider, and clicks the bottom-right Save button — concluding with a settings-saved confirmation toast. Shows cursor-driven interactions across multiple interactive primitives in sequence.
 
-## Installation
-
 <InstallBlock name="settings-toggle-flow" />
 
 <Note>
@@ -40,9 +38,7 @@ Installing `settings-toggle-flow` automatically installs the shared `remocn-ui` 
 
 The card surface fades in place (frames 0–18), then the header and each control group blur-in staggered, all settling by frame 58. The cursor moves to the notifications switch and clicks to toggle it on (frame 68). It arrives at the theme select trigger and clicks to open the panel (99), moves to the last option and clicks to select it (124), closing the dropdown. It then drags the volume slider — holding the pressed state while the value animates from frame 149 to 194. After releasing, the cursor moves to the bottom-right Save button and clicks (224; press → success check). The settings-saved toast then appears at frame 240 and auto-dismisses at frame 300.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "title",

--- a/content/docs/ui/blocks/signup-flow.mdx
+++ b/content/docs/ui/blocks/signup-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A composition scene that renders a real shadcn-style signup card — header, labeled Full Name / Email / Password / Confirm Password fields, a primary "Create account" button, a "Sign up with Google" outline button, and a sign-in footer. The cursor fills each field top-to-bottom, then submits and receives a success confirmation via toast. Each step is driven by primitives orchestrated on a shared timeline.
 
-## Installation
-
 <InstallBlock name="signup-flow" />
 
 <Note>
@@ -39,9 +37,7 @@ The card chrome (surface, header, field labels, descriptions, and footer) is sta
 
 The scene opens with the cursor parked in the top-left. It clicks the Full Name field at frame 18 (the field focuses and types in), then Email at 52, Password at 96, and Confirm Password at 134 — each cursor-click frame matches that field's `active` frame, and each field's typed value reveals before the cursor moves on. At frame 176 the cursor reaches the Create account button (hover), which presses at 186, enters loading (spinner) at 192, and resolves to success at 234. Simultaneously at 234 the success toast slides in, auto-dismissing at 300.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "title",

--- a/content/docs/ui/blocks/telegram-chat-flow.mdx
+++ b/content/docs/ui/blocks/telegram-chat-flow.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A Telegram-skinned composition scene — a tailed-bubble message thread, a Telegram-style composer pill, and a contact header that flips to "typing…" while the other side replies. Outgoing messages type into the composer then send with blue double-check delivery marks; incoming replies are preceded by a "typing…" status in the header before the bubble arrives; reaction chips pop in after each message lands.
 
-## Installation
-
 <InstallBlock name="telegram-chat-flow" />
 
 <Note>
@@ -36,9 +34,7 @@ The block is otherwise self-contained: it owns its tailed bubble layout, in-bubb
 
 The scene opens with a focused Telegram composer. The first outgoing message types into the input pill, then sends — a blue tailed bubble enters from below and settles into the thread, its timestamp and double-check marks visible inside the bubble. The contact header switches to "typing…"; after a beat the reply bubble arrives (white, left-tailed) and a reaction chip pops in beneath it. The second outgoing message follows the same pattern, sending with delivery checks and its own reaction. The composer returns to idle.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "messages",

--- a/content/docs/ui/components/accordion.mdx
+++ b/content/docs/ui/components/accordion.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (closed, opened) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="accordion" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/alert-dialog.mdx
+++ b/content/docs/ui/components/alert-dialog.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (closed, opened) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The wrapper is transparent by design: AlertDialog is a modal layer meant to compose over another scene, so it does not paint an opaque background.
 
-## Installation
-
 <InstallBlock name="alert-dialog" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `12
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/blur-in.mdx
+++ b/content/docs/ui/components/blur-in.mdx
@@ -20,8 +20,6 @@ A state atom that wraps a **single child** and reveals it with blur + opacity + 
 
 Unlike the other remocn-ui atoms, `blur-in` is **theme-independent**: it carries no colors and has no `theme`/`mode`/`primary` props. Its only inputs are the motion knobs — `blur`, `direction`, and `distance`.
 
-## Installation
-
 <InstallBlock name="blur-in" />
 
 <Note>
@@ -149,9 +147,7 @@ export const Scene = () => {
 
 Each child gets its own `useBlurInTransition`, staggered by its index.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/button.mdx
+++ b/content/docs/ui/components/button.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (idle, hover, press, loading, success) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="button" />
 
 <Note>
@@ -98,9 +96,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 `style` takes precedence over `state` when both are provided.
 
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/caret.mdx
+++ b/content/docs/ui/components/caret.mdx
@@ -20,8 +20,6 @@ A **text caret**: a thin vertical bar you can drive two ways. Pass a controlled 
 
 It is the shared caret behind the `input` primitive and the `claude-chat` composition.
 
-## Installation
-
 <InstallBlock name="caret" />
 
 ## Usage
@@ -53,9 +51,7 @@ halfPeriod = fps / blinkPerSecond / 2
 
 When `opacity` is provided it always wins; otherwise `blink` drives the bar, and with neither the caret stays solid.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "color",

--- a/content/docs/ui/components/checkbox.mdx
+++ b/content/docs/ui/components/checkbox.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (checked, unchecked) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="checkbox" />
 
 <Note>
@@ -91,9 +89,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 `style` takes precedence over `state` when both are provided.
 
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/combobox.mdx
+++ b/content/docs/ui/components/combobox.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom representing a searchable select: a text-input trigger and a panel of filtered options. Its appearance (`opened`, `closed`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The panel reveals below the trigger with opacity, scale, and vertical lift animations. The trigger reuses the Input visual presets; the panel rows reuse the SelectItem atom.
 
-## Installation
-
 <InstallBlock name="combobox" />
 
 <Note>
@@ -167,9 +165,7 @@ const itemStyle = useSelectItemTransition([
 <Combobox style={panelStyle} itemStyles={[itemStyle]} />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/command-menu.mdx
+++ b/content/docs/ui/components/command-menu.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom representing a command palette panel. Its appearance (`opened`, `closed`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The panel zooms in from 0.96 scale with a backdrop dim and fades fully in on open; reverses on close.
 
-## Installation
-
 <InstallBlock name="command-menu" />
 
 <Note>
@@ -182,9 +180,7 @@ const itemStyle = useCommandMenuItemTransition([
 <CommandMenu style={panelStyle} itemStyles={[itemStyle]} />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/context-menu.mdx
+++ b/content/docs/ui/components/context-menu.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom representing a context menu panel. Its appearance (`opened`, `closed`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. Unlike `DropdownMenu`, there is no built-in trigger — the context menu opens at the cursor click point and the **caller** positions it there. The panel grows from its top-left corner (the click point) with opacity, scale, and vertical lift.
 
-## Installation
-
 <InstallBlock name="context-menu" />
 
 <Note>
@@ -172,9 +170,7 @@ const rowStyle = useDropdownMenuItemTransition([{ at: 0, state: rowState }]);
 <ContextMenu style={menuStyle} itemStyles={[undefined, rowStyle, undefined, undefined]} />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/cursor.mdx
+++ b/content/docs/ui/components/cursor.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A motion atom that renders an animated cursor as a pure function of the `CursorStyle` it receives. The cursor reads no frame itself — the single time source is `useCursorPath` on the caller's side, which folds a path of waypoints into a resolved position, ripple, and press-dip visual. This is the **value-channel** variant of the primitive pattern: instead of a string-state timeline it drives numeric position channels directly.
 
-## Installation
-
 <InstallBlock name="cursor" />
 
 <Note>
@@ -137,9 +135,7 @@ const style = useCursorPath([
 ]);
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "style",

--- a/content/docs/ui/components/dialog.mdx
+++ b/content/docs/ui/components/dialog.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (closed, opened) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The wrapper is transparent by design: Dialog is a modal layer meant to compose over another scene, so it does not paint an opaque background. Unlike AlertDialog, Dialog is a generic (non-destructive) modal — its primary action uses the theme `primary` color, and it renders a close (X) button in the top-right corner of the popup card.
 
-## Installation
-
 <InstallBlock name="dialog" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `12
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/drawer.mdx
+++ b/content/docs/ui/components/drawer.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (closed, opened) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The wrapper is transparent by design: Drawer is a modal layer meant to compose over another scene, so it does not paint an opaque background. The panel is anchored to the bottom edge and slides up into view: it has rounded top corners, a drag-handle pill at the top, and no close (X) button — the handle stands in for the dismiss affordance.
 
-## Installation
-
 <InstallBlock name="drawer" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `12
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/dropdown-menu.mdx
+++ b/content/docs/ui/components/dropdown-menu.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom representing a complete dropdown menu: a trigger button and a panel of actionable items. Its appearance (opened, closed) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The panel reveals below the trigger with opacity, scale, and vertical translation animations.
 
-## Installation
-
 <InstallBlock name="dropdown-menu" />
 
 <Note>
@@ -117,9 +115,7 @@ Preview a single DropdownMenuItem:
 
 When you install `dropdown-menu`, the `dropdown-menu-item` atom is automatically pulled in via `registryDependencies` — no separate install needed. The `DropdownMenu` container derives each row's state from the `highlightedIndex` and `pressedIndex` props, or you can override a row's visual with `itemStyles`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/field.mdx
+++ b/content/docs/ui/components/field.mdx
@@ -20,8 +20,6 @@ you place inside it.
 
 The nesting order is `FieldGroup` ▸ `Field` ▸ `FieldLabel` / `FieldControl` / `FieldDescription`.
 
-## Installation
-
 <InstallBlock name="field" />
 
 <Note>

--- a/content/docs/ui/components/input.mdx
+++ b/content/docs/ui/components/input.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (idle, hover, active, typing, blur, invalid) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="input" />
 
 <Note>
@@ -98,9 +96,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/message-bubble.mdx
+++ b/content/docs/ui/components/message-bubble.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (`hidden`, `visible`) is a pure function of the `state` prop. The bubble enters from 12 px below at 0.94 scale, fades and scales up to rest. Incoming bubbles align to the left on `theme.muted`; outgoing bubbles align to the right on `theme.primary`. An optional reaction emoji badge pops in via the `reactionStyle` channel.
 
-## Installation
-
 <InstallBlock name="message-bubble" />
 
 <Note>
@@ -98,9 +96,7 @@ Pass a reaction emoji string to the `reaction` prop to render an emoji badge anc
 
 When `reaction` is omitted no badge is rendered.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/popover.mdx
+++ b/content/docs/ui/components/popover.mdx
@@ -20,8 +20,6 @@ A state atom whose appearance (`closed`, `opened`) is a pure function of the `st
 
 The hover-card pattern (a rich profile card that appears on hover) is this component driven by hover timing: use `usePopoverTransition` with steps that match when a `Cursor` arrives at and leaves the anchor.
 
-## Installation
-
 <InstallBlock name="popover" />
 
 <Note>
@@ -148,9 +146,7 @@ Placement is the caller's responsibility. The popover renders inline — wrap it
 
 For `"bottom"`, use `top: "calc(100% + 12px)"` instead. For `"left"` / `"right"`, use `right: "calc(100% + 12px)"` / `left: "calc(100% + 12px)"` and adjust vertical alignment to `top: "50%"` with `translateY(-50%)`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/progress.mdx
+++ b/content/docs/ui/components/progress.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A value-channel atom whose fill (`0`–`100`) is a pure function of the `value` prop or an interpolated `ProgressStyle` from `useProgressTransition`. The component reads no frame — only the value you give it. This is the **value-channel** variant of the primitive pattern: instead of a string-state timeline it drives a numeric fill channel directly, the same deviation used by the Cursor primitive.
 
-## Installation
-
 <InstallBlock name="progress" />
 
 <Note>
@@ -96,9 +94,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `24
 
 `style` takes precedence over `value` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "value",

--- a/content/docs/ui/components/radio.mdx
+++ b/content/docs/ui/components/radio.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (checked, unchecked) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="radio" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/resizable.mdx
+++ b/content/docs/ui/components/resizable.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A dual-channel value atom whose panel split ratio (`0`–`1`) and handle appearance (`idle`, `hover`, `press`) are a pure function of the props it receives. The component reads no frame. This is a **dual-channel** variant of the value-channel pattern: `useResizableTransition` drives a numeric ratio channel and a handle-state channel independently through one `ResizableStyle`, so cursor-synced drag scenes compose naturally — the same pattern as the Slider primitive.
 
-## Installation
-
 <InstallBlock name="resizable" />
 
 <Note>
@@ -156,9 +154,7 @@ Both `"horizontal"` (default) and `"vertical"` are implemented. Horizontal split
 <Resizable style={style} direction="vertical" />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "first",

--- a/content/docs/ui/components/select.mdx
+++ b/content/docs/ui/components/select.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 A state atom representing a complete select dropdown: a trigger button and a panel of selectable items. Its appearance (opened, closed) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The panel reveals below the trigger with opacity, scale, and vertical translation animations.
 
-## Installation
-
 <InstallBlock name="select" />
 
 <Note>
@@ -120,9 +118,7 @@ Preview a single SelectItem:
 
 When you install `select`, the `select-item` atom is automatically pulled in via `registryDependencies` — no separate install needed. The `Select` container derives each row's state from the `selectedIndex`, `highlightedIndex`, and `pressedIndex` props, or you can override a row's visual with `itemStyles`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/sheet.mdx
+++ b/content/docs/ui/components/sheet.mdx
@@ -19,8 +19,6 @@ avoidWhen:
 
 A state atom whose appearance (closed, opened) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The wrapper is transparent by design: Sheet is a modal layer meant to compose over another scene, so it does not paint an opaque background. Unlike Dialog (a centered popup that zooms in), Sheet is a right-edge side panel: a full-height flush panel anchored to the right that slides in horizontally, with a close (X) button in its top-right corner.
 
-## Installation
-
 <InstallBlock name="sheet" />
 
 <Note>
@@ -91,9 +89,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `12
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/skeleton-block.mdx
+++ b/content/docs/ui/components/skeleton-block.mdx
@@ -22,8 +22,6 @@ Unlike most primitives in this tier it has no `state` — it is always shimmerin
 you are laying out a placeholder yourself; reach for `skeleton` when you want the loading-to-loaded
 crossfade handled for you.
 
-## Installation
-
 <InstallBlock name="skeleton-block" />
 
 <Note>
@@ -72,9 +70,7 @@ fixed-width block sits next to a flexible one.
 </div>
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "width",

--- a/content/docs/ui/components/skeleton.mdx
+++ b/content/docs/ui/components/skeleton.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom that crossfades between a shimmer placeholder and real content. Its appearance (`loading`, `loaded`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the animated `SkeletonBlock` motion atom inside the placeholder does. The two opacity layers always sum to 1 so the crossfade never dims the bounding box.
 
-## Installation
-
 <InstallBlock name="skeleton" />
 
 <Note>
@@ -168,9 +166,7 @@ import { SkeletonBlock } from "@/components/remocn/skeleton-block";
 
 When you install `skeleton`, `skeleton-block` is automatically pulled in via `registryDependencies` — no separate install needed.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/slider.mdx
+++ b/content/docs/ui/components/slider.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A dual-channel value atom whose fill (`0`–`100`) and thumb appearance (`idle`, `hover`, `press`) are a pure function of the props it receives. The component reads no frame. This is a **dual-channel** variant of the value-channel pattern: `useSliderTransition` drives a numeric fill channel and a thumb-state channel independently through one `SliderStyle`, so cursor-synced drag scenes compose naturally.
 
-## Installation
-
 <InstallBlock name="slider" />
 
 <Note>
@@ -146,9 +144,7 @@ export const Scene = () => {
 
 The cursor's drag frames (`at: 44` → `at: 100`, duration 56) match the value-channel move exactly. The thumb-state transitions (`hover` at 30, `press` at 44, `idle` at 108) are independent — they run on their own mini-durations without disturbing the fill easing.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "value",

--- a/content/docs/ui/components/spinner.mdx
+++ b/content/docs/ui/components/spinner.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A **motion atom**: a looping animation that is a pure function of `useCurrentFrame()`. No states, no props to sequence — just a spinning arc that advances deterministically with the timeline. Safe in Remotion's headless per-frame renderer (no `Date`, `Math.random`, or `requestAnimationFrame`).
 
-## Installation
-
 <InstallBlock name="spinner" />
 
 <Note>
@@ -54,9 +52,7 @@ rotation (deg) = frame × speed × 6
 
 At 30 fps with `speed=1`, one full rotation takes 20 frames (2 frames per 12°). Increase `speed` to spin faster without changing the composition fps.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "size",

--- a/content/docs/ui/components/stepper.mdx
+++ b/content/docs/ui/components/stepper.mdx
@@ -20,8 +20,6 @@ A value-channel atom whose active position (`0`–`n-1`) is a pure function of t
 
 As `position` advances, each circle fills from muted to primary, the checkmark draws in, and the connector between steps fills — all derived purely from the single float `position` value.
 
-## Installation
-
 <InstallBlock name="stepper" />
 
 <Note>
@@ -102,9 +100,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` (= `24
 
 Only `"horizontal"` is implemented in this release. Passing `orientation="vertical"` is accepted but falls back to horizontal — vertical layout is planned for a future wave.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "steps",

--- a/content/docs/ui/components/switch.mdx
+++ b/content/docs/ui/components/switch.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (checked, unchecked) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="switch" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/tabs.mdx
+++ b/content/docs/ui/components/tabs.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (which tab is active) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="tabs" />
 
 <Note>
@@ -90,9 +88,7 @@ The `duration` field on each step overrides the file's `DEFAULT_DURATION` for th
 
 `style` takes precedence over `state` when both are provided.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/toast.mdx
+++ b/content/docs/ui/components/toast.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (`hidden`, `visible`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The toast enters from 16 px below at 0.97 scale, fades and scales up to rest, then reverses on dismiss.
 
-## Installation
-
 <InstallBlock name="toast" />
 
 <Note>
@@ -126,9 +124,7 @@ type ToastVariant =
 <Toast state="visible" title="Heads up"         variant="default" />
 ```
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "title",

--- a/content/docs/ui/components/toggle-group.mdx
+++ b/content/docs/ui/components/toggle-group.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom representing a segmented button control — a row of labeled segments with a sliding thumb indicator that moves to the active one. Its appearance (which segment is active) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it.
 
-## Installation
-
 <InstallBlock name="toggle-group" />
 
 <Note>
@@ -110,9 +108,7 @@ The `size` prop sets the overall scale of the control:
 | `"default"` | Standard — pricing toggles, view switches |
 | `"sm"` | Compact toolbar toggles |
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "state",

--- a/content/docs/ui/components/tooltip.mdx
+++ b/content/docs/ui/components/tooltip.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A state atom whose appearance (`hidden`, `visible`) is a pure function of the `state` prop. Pass a state directly or drive it from the Remotion timeline via `useCurrentState`. The component reads no frame — only the state value you give it. The tooltip fades in at 0.96 scale, slides 4 px toward the anchor, and rests fully visible; `hidden` reverses the motion. Placement is the caller's responsibility — the tooltip renders inline and the caller wraps it in an absolutely-positioned anchor div.
 
-## Installation
-
 <InstallBlock name="tooltip" />
 
 <Note>
@@ -144,9 +142,7 @@ Placement is the caller's responsibility. The tooltip renders inline — wrap it
 
 For `"bottom"`, use `top: "calc(100% + 12px)"` instead. For `"left"` / `"right"`, use `right: "calc(100% + 12px)"` / `left: "calc(100% + 12px)"` and adjust vertical alignment to `top: "50%"` with `translateY(-50%)`.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "label",

--- a/content/docs/ui/components/typing-indicator.mdx
+++ b/content/docs/ui/components/typing-indicator.mdx
@@ -18,8 +18,6 @@ avoidWhen:
 
 A motion atom that reads `useCurrentFrame` directly and produces N dots bouncing with staggered sine offsets. No state prop — the animation runs continuously as long as the component is mounted on the timeline. Drop it into any bubble or container to signal that a message is being composed.
 
-## Installation
-
 <InstallBlock name="typing-indicator" />
 
 <Note>
@@ -45,9 +43,7 @@ export const Scene = () => (
 
 The helper `typingDotOffset(frame, index, opts)` is exported for cases where you want to drive individual dot positions from your own layout.
 
-## Props
-
-<PropsTable
+<PropsTable title="Props"
   rows={[
     {
       name: "dotCount",

--- a/lib/mdx-to-markdown.ts
+++ b/lib/mdx-to-markdown.ts
@@ -300,6 +300,8 @@ export function mdxToMarkdown(src: string, siteUrl: string): string {
           let replacement = "";
           if (tag === "InstallBlock" && typeof attrs.name === "string") {
             replacement = [
+              "## Installation",
+              "",
               "```bash",
               `npx shadcn@latest add @remocn/${attrs.name}`,
               "```",
@@ -308,6 +310,9 @@ export function mdxToMarkdown(src: string, siteUrl: string): string {
             replacement = ["```bash", INSTALL_ALL_COMMAND, "```"].join("\n");
           } else if (tag === "PropsTable") {
             replacement = renderPropsTable(attrs.rows);
+            if (typeof attrs.title === "string") {
+              replacement = `## ${attrs.title}\n\n${replacement}`;
+            }
           } else if (tag === "ComponentCardGrid") {
             replacement = renderCardGrid(attrs.items, siteUrl);
           } else if (tag === "Dependencies") {

--- a/lib/ui-preview-internals.tsx
+++ b/lib/ui-preview-internals.tsx
@@ -75,6 +75,7 @@ export function PreviewStage({
   compositionWidth,
   compositionHeight,
   previewBackdrop,
+  className,
 }: {
   name: string;
   // biome-ignore lint/suspicious/noExplicitAny: dynamically-loaded Remotion composition, props shape varies per component
@@ -87,6 +88,7 @@ export function PreviewStage({
   compositionWidth: number;
   compositionHeight: number;
   previewBackdrop?: BackdropFill;
+  className?: string;
 }) {
   const [mounted, setMounted] = useState(false);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -193,7 +195,10 @@ export function PreviewStage({
       // (aspect-video), staying full-width and aligned with the tabs/customize
       // panel. The Suspense fallback above uses the same ratio to keep zero
       // layout shift.
-      className="surface-card aspect-video w-full overflow-hidden rounded-2xl"
+      className={cn(
+        "aspect-video w-full overflow-hidden",
+        className ?? "surface-card rounded-2xl",
+      )}
     >
       {mounted ? (
         <div

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -17,6 +17,7 @@ import { InstallAll } from "@/components/docs/install-all";
 import { InstallBlock } from "@/components/docs/install-block";
 import { PropsTable } from "@/components/docs/props-table";
 import { UiComponentPreview } from "@/components/docs/ui-component-preview";
+import { Frame, FramePanel } from "@/components/ui/frame";
 import { cn } from "@/lib/utils";
 
 /**
@@ -50,6 +51,19 @@ function Pre({ className, ...props }: ComponentProps<"pre">) {
       )}
       {...props}
     />
+  );
+}
+
+function Figure(props: ComponentProps<"figure">) {
+  if (!("data-rehype-pretty-code-figure" in props)) {
+    return <figure {...props} />;
+  }
+  return (
+    <Frame className="not-prose my-6">
+      <FramePanel className="overflow-hidden p-0 [&>figure]:my-0">
+        <figure {...props} />
+      </FramePanel>
+    </Frame>
   );
 }
 
@@ -100,6 +114,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...(defaultMdxComponents as MDXComponents),
     pre: Pre,
+    figure: Figure,
     figcaption: Figcaption,
     code: Code,
 


### PR DESCRIPTION
## What's in here

### Docs: coss-style Frame everywhere
- New `components/ui/frame.tsx` (port of coss.com/ui Frame: muted tray + bordered panel), wrapping the component preview (tabs in the tray, player stage in the panel), Customize, Installation, Props, MDX code fences, and the sponsors rail widget.
- Installation/Props headings move from MDX into the frame header: 189 `## Installation` and 144 `## Props` headings removed from MDX sources; anchors preserved via ids on the frames, and `mdx-to-markdown` re-emits the headings so `/docs/**.md` agent output is unchanged. TOC loses those two entries (heading no longer in MDX).
- Controls get a framed surface: `.control-surface` (inset ring + soft top highlight) replaces the flat `bg-control` border. Renamed because tailwind-merge treated the `bg-` prefix as a background utility and stripped the class — that's why the slider's border only showed on hover.
- Docs typography pass: title drops Outfit (font unregistered, one less woff2), steps down to `text-3xl/4xl`; description tightens to `max-w-xl`; Copy Markdown sits beside the title; docs header mirrors the fumadocs grid so the nav shares the article column's left edge; customizer controls shrink to h-9; sponsor tiles get concentric radii.

### Landing: What's inside → editor timeline
- The five category cards become a Screen-Studio-style timeline: monitor canvas on top playing the active family's preview, frame-code ruler, one track of five saturated clip pills sized by their timeline seconds, and a looping playhead that activates the clip under it (hover/focus overrides; reduced motion parks it).
- The Transitions preview is now a real registry `zoomBlur` playing in `@remotion/player` between two bare color fills — no more hand-drawn framer-motion imitation.
- Fixed the how-it-works typing caret drifting away from the text (width animated in `ch` instead of `%`).

### Buttons & customizer (coss recipes)
- Button: outline variant gets border+shadow+inset highlight depth, presses add a soft inset shade, and a `loading` prop renders the Spinner and disables the button.
- Customizer number input replaced with `@coss/number-field` (Base UI): scrub-area label, built-in min/max clamping; hand-rolled draft/commit logic deleted. `@coss` registry added to components.json.

## Checks
- `bun test lib/docs-meta.test.ts` — 14/14 (blocking CI gate)
- `tsc --noEmit`, biome — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D3Q8gxQVowhDs7DS4qASQ