### PR TITLE
Sidebar category icons, badge and secondary cleanup

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -32,7 +32,7 @@ export default async function Page(props: {
           <CopyMarkdownButton url={`${page.url}.md`} className="shrink-0" />
         ) : null}
       </div>
-      <DocsDescription className="mt-3 mb-0 max-w-xl text-pretty text-base text-muted-foreground md:text-lg">
+      <DocsDescription className="mb-0 max-w-xl text-pretty text-base text-muted-foreground md:text-lg">
         {data.description}
       </DocsDescription>
       <div className="typeset typeset-docs mt-8 flex-1">

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,12 +103,6 @@
   --code-highlight: oklch(0.93 0.004 214.3);
   --code-number: oklch(0.56 0.021 213.5);
 
-  /* "NEW" sidebar badge — editable accent. Theme-agnostic for now (same value
-     in light/dark); recolor the badge by changing --badge-new-bg here. The fg
-     stays dark so the label reads on the light-lime background. */
-  --badge-new-bg: rgb(195, 232, 141);
-  --badge-new-fg: oklch(0.205 0 0);
-
   --elevation-raised:
     0 0 0 1px rgb(0 0 0 / 0.05), 0 1px 3px rgb(0 0 0 / 0.05), 0 4px 10px -4px
     rgb(0 0 0 / 0.05);
@@ -163,10 +157,6 @@
   --code-foreground: oklch(0.987 0.002 197.1);
   --code-highlight: oklch(0.225 0.008 224);
   --code-number: oklch(0.56 0.021 213.5);
-
-  /* Badge keeps the same lime accent in dark mode — see :root for the knob. */
-  --badge-new-bg: rgb(195, 232, 141);
-  --badge-new-fg: oklch(0.205 0 0);
 
   --elevation-raised: 0 0 0 1px rgb(255 255 255 / 0.09);
   --elevation-raised-hover: 0 0 0 1px rgb(255 255 255 / 0.14);
@@ -456,20 +446,10 @@
 #nd-sidebar-mobile a.w-full,
 #nd-sidebar [data-radix-scroll-area-viewport] button.w-full,
 #nd-sidebar-mobile [data-radix-scroll-area-viewport] button.w-full {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  color: var(--muted-foreground);
-
+  font-size: 0.8125rem;
+  letter-spacing: -0.01em;
+  font-weight: 500;
   margin-top: 0.25rem;
-}
-#nd-sidebar a.w-full:hover,
-#nd-sidebar-mobile a.w-full:hover,
-#nd-sidebar [data-radix-scroll-area-viewport] button.w-full:hover,
-#nd-sidebar-mobile [data-radix-scroll-area-viewport] button.w-full:hover {
-  color: var(--foreground);
-  background-color: transparent;
 }
 
 #nd-sidebar [data-radix-scroll-area-viewport] a.w-full + div,

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource/manrope": "^5.2.8",
+        "@hugeicons/core-free-icons": "^4.3.0",
+        "@hugeicons/react": "^1.1.10",
         "@openpanel/nextjs": "^1.0.13",
         "@openpanel/sdk": "^1.3.1",
         "@paper-design/shaders-react": "0.0.76",
@@ -231,6 +233,10 @@
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.3", "", { "dependencies": { "postcss-selector-parser": "^7.1.1" }, "peerDependencies": { "tailwindcss": "^4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-/FWcggMz9BhoX+13xBoZLX+XX9mYvJ50dkTqy3IfocJqua65ExcsKfxwKH8hgTO3vA5KnWv4+4jU7LaW2AjAmQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.3.0", "", {}, "sha512-5DC5gq2psNDKBQThOjpuFCtMco8nl2FkrBzZgG15cFGM0kSwUoych/pw0DmjBygF9qRDITdBPtmzJqLsOeImMg=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.10", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-9tAsd92yMVVGP+E+d8cM+wc0VnXuYZHNbWQi7TOe8k2neawmhiaFmVFbzyruejhOMa197/LbgvSED32ayUo3ZA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/components/docs/new-badge.tsx
+++ b/components/docs/new-badge.tsx
@@ -1,16 +1,15 @@
-import { ShimmeringText } from "@/components/shimmering-text";
 import { cn } from "@/lib/utils";
 
 export function NewBadge({ className }: { className?: string }) {
   return (
-    <ShimmeringText
-      text="NEW"
-      duration={1.2}
+    <span
       className={cn(
-        "ms-auto rounded-full px-1.5 text-[10px] font-semibold uppercase leading-[1.45] tracking-wide",
-        "bg-[var(--badge-new-bg)] [--color:var(--badge-new-fg)] [--shimmering-color:color-mix(in_oklch,var(--badge-new-fg),transparent_55%)]",
+        "ms-auto rounded-full bg-primary/10 px-1.5 py-px text-[10px] font-medium leading-[1.45]",
+        "text-primary dark:bg-primary/20 dark:text-[color-mix(in_oklab,var(--primary)_55%,white)]",
         className,
       )}
-    />
+    >
+      New
+    </span>
   );
 }

--- a/components/ui/frame.tsx
+++ b/components/ui/frame.tsx
@@ -5,7 +5,7 @@ function Frame({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "relative flex flex-col rounded-2xl bg-muted/72 p-1 dark:bg-secondary",
+        "relative flex flex-col rounded-2xl bg-secondary/72 p-1 dark:bg-secondary",
         "*:[[data-slot=frame-panel]+[data-slot=frame-panel]]:mt-1",
         className,
       )}

--- a/content/docs/ai/meta.json
+++ b/content/docs/ai/meta.json
@@ -1,5 +1,13 @@
 {
   "title": "AI",
   "defaultOpen": false,
-  "pages": ["index", "claude-chat", "chat-gpt", "v0", "claude-code", "opencode"]
+  "pages": [
+    "index",
+    "claude-chat",
+    "chat-gpt",
+    "v0",
+    "claude-code",
+    "opencode"
+  ],
+  "icon": "ArtificialIntelligence04Icon"
 }

--- a/content/docs/compositions/meta.json
+++ b/content/docs/compositions/meta.json
@@ -6,5 +6,6 @@
     "ecosystem-constellation",
     "infinite-bento-pan",
     "live-code-compilation"
-  ]
+  ],
+  "icon": "Layers01Icon"
 }

--- a/content/docs/craft/meta.json
+++ b/content/docs/craft/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "Craft",
   "defaultOpen": false,
-  "pages": ["index", "design-defaults", "motion-principles", "anti-patterns"]
+  "pages": [
+    "index",
+    "design-defaults",
+    "motion-principles",
+    "anti-patterns"
+  ],
+  "icon": "MagicWand01Icon"
 }

--- a/content/docs/craft/meta.json
+++ b/content/docs/craft/meta.json
@@ -1,11 +1,6 @@
 {
   "title": "Craft",
   "defaultOpen": false,
-  "pages": [
-    "index",
-    "design-defaults",
-    "motion-principles",
-    "anti-patterns"
-  ],
+  "pages": ["index", "design-defaults", "motion-principles", "anti-patterns"],
   "icon": "MagicWand01Icon"
 }

--- a/content/docs/effects/meta.json
+++ b/content/docs/effects/meta.json
@@ -10,5 +10,6 @@
     "scribble-circle",
     "crumple-toss",
     "simulated-cursor"
-  ]
+  ],
+  "icon": "SparklesIcon"
 }

--- a/content/docs/filters/components/meta.json
+++ b/content/docs/filters/components/meta.json
@@ -12,5 +12,6 @@
     "ascii-render",
     "halftone-print",
     "underwater-ripple"
-  ]
+  ],
+  "icon": "BlurIcon"
 }

--- a/content/docs/filters/getting-started/meta.json
+++ b/content/docs/filters/getting-started/meta.json
@@ -1,5 +1,8 @@
 {
   "title": "Getting Started",
   "collapsible": false,
-  "pages": ["introduction"]
+  "pages": [
+    "introduction"
+  ],
+  "icon": "Rocket01Icon"
 }

--- a/content/docs/filters/getting-started/meta.json
+++ b/content/docs/filters/getting-started/meta.json
@@ -1,8 +1,6 @@
 {
   "title": "Getting Started",
   "collapsible": false,
-  "pages": [
-    "introduction"
-  ],
+  "pages": ["introduction"],
   "icon": "Rocket01Icon"
 }

--- a/content/docs/filters/meta.json
+++ b/content/docs/filters/meta.json
@@ -1,9 +1,6 @@
 {
   "title": "Filters",
   "collapsible": false,
-  "pages": [
-    "getting-started",
-    "components"
-  ],
+  "pages": ["getting-started", "components"],
   "icon": "BlurIcon"
 }

--- a/content/docs/filters/meta.json
+++ b/content/docs/filters/meta.json
@@ -1,5 +1,9 @@
 {
   "title": "Filters",
   "collapsible": false,
-  "pages": ["getting-started", "components"]
+  "pages": [
+    "getting-started",
+    "components"
+  ],
+  "icon": "BlurIcon"
 }

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -1,5 +1,10 @@
 {
   "title": "Getting Started",
   "defaultOpen": true,
-  "pages": ["introduction", "installation", "agent-skill"]
+  "pages": [
+    "introduction",
+    "installation",
+    "agent-skill"
+  ],
+  "icon": "Rocket01Icon"
 }

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -1,10 +1,6 @@
 {
   "title": "Getting Started",
   "defaultOpen": true,
-  "pages": [
-    "introduction",
-    "installation",
-    "agent-skill"
-  ],
+  "pages": ["introduction", "installation", "agent-skill"],
   "icon": "Rocket01Icon"
 }

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -13,5 +13,6 @@
     "directing-your-agent",
     "words-on-screen",
     "your-brand"
-  ]
+  ],
+  "icon": "BookOpen01Icon"
 }

--- a/content/docs/icons/meta.json
+++ b/content/docs/icons/meta.json
@@ -1,8 +1,6 @@
 {
   "title": "Icons",
   "collapsible": false,
-  "pages": [
-    "gallery"
-  ],
+  "pages": ["gallery"],
   "icon": "SparklesIcon"
 }

--- a/content/docs/icons/meta.json
+++ b/content/docs/icons/meta.json
@@ -1,5 +1,8 @@
 {
   "title": "Icons",
   "collapsible": false,
-  "pages": ["gallery"]
+  "pages": [
+    "gallery"
+  ],
+  "icon": "SparklesIcon"
 }

--- a/content/docs/layout/meta.json
+++ b/content/docs/layout/meta.json
@@ -1,12 +1,6 @@
 {
   "title": "Layout",
   "defaultOpen": false,
-  "pages": [
-    "index",
-    "backdrop",
-    "drift",
-    "chat-to-preview-layout",
-    "stage"
-  ],
+  "pages": ["index", "backdrop", "drift", "chat-to-preview-layout", "stage"],
   "icon": "Layout01Icon"
 }

--- a/content/docs/layout/meta.json
+++ b/content/docs/layout/meta.json
@@ -1,5 +1,12 @@
 {
   "title": "Layout",
   "defaultOpen": false,
-  "pages": ["index", "backdrop", "drift", "chat-to-preview-layout", "stage"]
+  "pages": [
+    "index",
+    "backdrop",
+    "drift",
+    "chat-to-preview-layout",
+    "stage"
+  ],
+  "icon": "Layout01Icon"
 }

--- a/content/docs/shaders/components/meta.json
+++ b/content/docs/shaders/components/meta.json
@@ -24,5 +24,6 @@
     "shader-gem-smoke",
     "shader-strata",
     "shader-weave"
-  ]
+  ],
+  "icon": "ColorsIcon"
 }

--- a/content/docs/shaders/getting-started/meta.json
+++ b/content/docs/shaders/getting-started/meta.json
@@ -1,5 +1,8 @@
 {
   "title": "Getting Started",
   "collapsible": false,
-  "pages": ["introduction"]
+  "pages": [
+    "introduction"
+  ],
+  "icon": "Rocket01Icon"
 }

--- a/content/docs/shaders/getting-started/meta.json
+++ b/content/docs/shaders/getting-started/meta.json
@@ -1,8 +1,6 @@
 {
   "title": "Getting Started",
   "collapsible": false,
-  "pages": [
-    "introduction"
-  ],
+  "pages": ["introduction"],
   "icon": "Rocket01Icon"
 }

--- a/content/docs/shaders/meta.json
+++ b/content/docs/shaders/meta.json
@@ -1,9 +1,6 @@
 {
   "title": "Shaders",
   "collapsible": false,
-  "pages": [
-    "getting-started",
-    "components"
-  ],
+  "pages": ["getting-started", "components"],
   "icon": "ColorsIcon"
 }

--- a/content/docs/shaders/meta.json
+++ b/content/docs/shaders/meta.json
@@ -1,5 +1,9 @@
 {
   "title": "Shaders",
   "collapsible": false,
-  "pages": ["getting-started", "components"]
+  "pages": [
+    "getting-started",
+    "components"
+  ],
+  "icon": "ColorsIcon"
 }

--- a/content/docs/social/meta.json
+++ b/content/docs/social/meta.json
@@ -8,5 +8,6 @@
     "x-follow-card",
     "x-followers-overview",
     "logo-enter"
-  ]
+  ],
+  "icon": "Share01Icon"
 }

--- a/content/docs/transitions/meta.json
+++ b/content/docs/transitions/meta.json
@@ -27,5 +27,6 @@
     "displacement",
     "slide-swap",
     "spring-settle"
-  ]
+  ],
+  "icon": "TransitionRightIcon"
 }

--- a/content/docs/typography/meta.json
+++ b/content/docs/typography/meta.json
@@ -60,5 +60,6 @@
     "extrude-pop",
     "chromatic-wave",
     "stretch-in"
-  ]
+  ],
+  "icon": "TextFontIcon"
 }

--- a/content/docs/ui-blocks/meta.json
+++ b/content/docs/ui-blocks/meta.json
@@ -13,5 +13,6 @@
     "polaroid",
     "check-list",
     "reel"
-  ]
+  ],
+  "icon": "DashboardSquare01Icon"
 }

--- a/content/docs/ui/blocks/meta.json
+++ b/content/docs/ui/blocks/meta.json
@@ -11,5 +11,6 @@
     "onboarding-stepper-flow",
     "ai-prompt-flow",
     "settings-toggle-flow"
-  ]
+  ],
+  "icon": "DashboardSquare01Icon"
 }

--- a/content/docs/ui/components/meta.json
+++ b/content/docs/ui/components/meta.json
@@ -35,5 +35,6 @@
     "toggle-group",
     "tooltip",
     "typing-indicator"
-  ]
+  ],
+  "icon": "ToggleOnIcon"
 }

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,5 +1,12 @@
 {
   "title": "UI",
   "collapsible": false,
-  "pages": ["index", "concepts", "installation", "components", "blocks"]
+  "pages": [
+    "index",
+    "concepts",
+    "installation",
+    "components",
+    "blocks"
+  ],
+  "icon": "ToggleOnIcon"
 }

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,12 +1,6 @@
 {
   "title": "UI",
   "collapsible": false,
-  "pages": [
-    "index",
-    "concepts",
-    "installation",
-    "components",
-    "blocks"
-  ],
+  "pages": ["index", "concepts", "installation", "components", "blocks"],
   "icon": "ToggleOnIcon"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@fontsource/manrope": "^5.2.8",
+    "@hugeicons/core-free-icons": "^4.3.0",
+    "@hugeicons/react": "^1.1.10",
     "@openpanel/nextjs": "^1.0.13",
     "@openpanel/sdk": "^1.3.1",
     "@paper-design/shaders-react": "0.0.76",

--- a/source.ts
+++ b/source.ts
@@ -1,7 +1,0 @@
-import { loader } from "fumadocs-core/source";
-import { docs } from "@/.source/server";
-
-export const source = loader({
-  baseUrl: "/docs",
-  source: docs.toFumadocsSource(),
-});

--- a/source.tsx
+++ b/source.tsx
@@ -1,0 +1,48 @@
+import {
+  ArtificialIntelligence04Icon,
+  BlurIcon,
+  BookOpen01Icon,
+  ColorsIcon,
+  DashboardSquare01Icon,
+  Layers01Icon,
+  Layout01Icon,
+  MagicWand01Icon,
+  Rocket01Icon,
+  Share01Icon,
+  SparklesIcon,
+  TextFontIcon,
+  ToggleOnIcon,
+  TransitionRightIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import { loader } from "fumadocs-core/source";
+import { docs } from "@/.source/server";
+
+/** Sidebar category icons — meta.json `icon` values resolve against this map. */
+const DOCS_ICONS: Record<string, IconSvgElement> = {
+  ArtificialIntelligence04Icon,
+  BlurIcon,
+  BookOpen01Icon,
+  ColorsIcon,
+  DashboardSquare01Icon,
+  Layers01Icon,
+  Layout01Icon,
+  MagicWand01Icon,
+  Rocket01Icon,
+  Share01Icon,
+  SparklesIcon,
+  TextFontIcon,
+  ToggleOnIcon,
+  TransitionRightIcon,
+};
+
+export const source = loader({
+  baseUrl: "/docs",
+  icon(icon) {
+    if (!icon) return;
+    const svg = DOCS_ICONS[icon];
+    if (!svg) return;
+    return <HugeiconsIcon icon={svg} strokeWidth={1.8} />;
+  },
+  source: docs.toFumadocsSource(),
+});


### PR DESCRIPTION
## What's in here

- **Sidebar categories like evilcharts**: hugeicons per category (`icon` field in 21 meta.json files, resolved in `source.tsx` via a `HugeiconsIcon` map; `@hugeicons/react` + `@hugeicons/core-free-icons` added). The globals.css override that turned folder triggers into uppercase mini-labels — and suppressed their hover — is gone: categories now hover exactly like menu items.
- **NEW badge**: static primary-tinted "New" pill — no shimmer, no uppercase; the lime `--badge-new-*` tokens removed.
- **Secondary consistency**: Frame tray uses `bg-secondary/72 dark:bg-secondary` (was muted in light / secondary in dark — one role, two tokens).
- Docs title row tweaks (Copy Markdown beside the title).

## Checks
- `bun test lib/docs-meta.test.ts` — 14/14
- `tsc --noEmit`, biome — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D3Q8gxQVowhDs7DS4qASQ