### PR TITLE
feat: new select-menu component

### DIFF
--- a/components/docs/examples/index.tsx
+++ b/components/docs/examples/index.tsx
@@ -77,6 +77,10 @@ import {
 } from "./security-cam-recipes";
 import { SelectExampleScene, selectExampleCode } from "./select-example";
 import {
+  SelectMenuExampleScene,
+  selectMenuExampleCode,
+} from "./select-menu-example";
+import {
   SharedAxisYExampleScene,
   sharedAxisYExampleCode,
 } from "./shared-axis-y-example";
@@ -232,6 +236,17 @@ export const examples: Record<string, ExampleEntry> = {
     code: selectExampleCode,
     // Panel closes at 96 + dur 12 = 108; a short settle then loop.
     durationInFrames: 120,
+    fps: FPS,
+    width: W,
+    height: H,
+    previewBackdrop: { type: "color", value: "oklch(1 0 0)" },
+  },
+  "select-menu-example": {
+    Component: SelectMenuExampleScene,
+    code: selectMenuExampleCode,
+    // Longest cycle (selectedIndex=3): glide 0→3 (60+12), click, selected hold,
+    // check fade-off, then instant restart jump at 78+14+20+8 = 120.
+    durationInFrames: 128,
     fps: FPS,
     width: W,
     height: H,

--- a/components/docs/examples/select-menu-example.tsx
+++ b/components/docs/examples/select-menu-example.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  SelectMenu,
+  type SelectMenuVariant,
+} from "@/registry/remocn-ui/select-menu";
+import { useSelectMenuTransition } from "@/registry/remocn-ui/select-menu/use-select-menu-transition";
+
+const DEFAULT_OPTIONS = ["New Game", "Continue", "Settings", "Quit"];
+
+const GLIDE_DUR = 12;
+const GLIDE_GAP = 20;
+const REST_AFTER_ARRIVAL = 6;
+const CLICK_DUR = 14;
+const SELECTED_HOLD = 20;
+const DECAY_DUR = 8;
+
+const clampIndex = (i: number): number =>
+  Math.max(0, Math.min(DEFAULT_OPTIONS.length - 1, Math.round(i)));
+
+function buildMenuTimeline(selectedIndex: number) {
+  const index = clampIndex(selectedIndex);
+  const steps: { at: number; state: string; duration: number }[] = [
+    { at: 0, state: DEFAULT_OPTIONS[0], duration: GLIDE_DUR },
+  ];
+  for (let i = 1; i <= index; i++) {
+    steps.push({
+      at: i * GLIDE_GAP,
+      state: DEFAULT_OPTIONS[i],
+      duration: GLIDE_DUR,
+    });
+  }
+  const arrival = index * GLIDE_GAP + GLIDE_DUR;
+  const clickAt = arrival + REST_AFTER_ARRIVAL;
+  // Decay completes first, then the indicator snaps back to row 0.
+  const resetAt = clickAt + CLICK_DUR + SELECTED_HOLD + DECAY_DUR;
+  steps.push({ at: resetAt, state: DEFAULT_OPTIONS[0], duration: 0 });
+  return { steps, clickAt, loop: resetAt };
+}
+
+export const selectMenuExampleControls = ["selectedIndex", "variant"] as const;
+
+export type SelectMenuExampleValues = {
+  selectedIndex?: number;
+  variant?: string;
+};
+
+export const SelectMenuExampleScene = ({
+  selectedIndex = 1,
+  variant = "soft",
+}: SelectMenuExampleValues) => {
+  const v = variant as SelectMenuVariant;
+  const { steps, clickAt } = buildMenuTimeline(selectedIndex);
+
+  const style = useSelectMenuTransition(steps, {
+    variant: v,
+    clickAt,
+    clickDuration: CLICK_DUR,
+    hold: SELECTED_HOLD,
+    decayDuration: DECAY_DUR,
+  });
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <SelectMenu style={style} options={DEFAULT_OPTIONS} variant={v} />
+    </div>
+  );
+};
+
+export const selectMenuExampleCode = (
+  values: Record<string, unknown> = {},
+): string => {
+  const selectedIndex = clampIndex((values.selectedIndex as number) ?? 1);
+  const variant = (values.variant as SelectMenuVariant) ?? "soft";
+  const { steps, clickAt } = buildMenuTimeline(selectedIndex);
+
+  const stepLines = steps
+    .map(
+      (s) =>
+        `    { at: ${s.at}, state: "${s.state}", duration: ${s.duration} },`,
+    )
+    .join("\n");
+
+  const props: string[] = [];
+  if (variant !== "soft") props.push(`    variant="${variant}"`);
+  const extraProps = props.length ? `\n${props.join("\n")}` : "";
+
+  return `import { SelectMenu } from "@/components/remocn/select-menu";
+import { useSelectMenuTransition } from "@/components/remocn/use-select-menu-transition";
+
+export const Scene = () => {
+  // Glides down to the selected option, clicks it (press + check mark), holds,
+  // then instantly jumps back to the first option for a clean restart.
+  const style = useSelectMenuTransition([
+${stepLines}
+  ], { clickAt: ${clickAt}, hold: ${SELECTED_HOLD}, decayDuration: ${DECAY_DUR} });
+
+  return (
+    <SelectMenu
+      style={style}${extraProps}
+    />
+  );
+};`;
+};

--- a/components/docs/examples/ui-preview-scenes.ts
+++ b/components/docs/examples/ui-preview-scenes.ts
@@ -68,6 +68,7 @@ export const UI_PREVIEW_TIMING: Record<string, UiPreviewTiming> = {
   radio: timing(100, WHITE),
   resizable: timing(205, WHITE),
   select: timing(120, WHITE),
+  "select-menu": timing(128, WHITE),
   sheet: timing(120, WHITE),
   skeleton: timing(220, WHITE),
   slider: timing(120, WHITE),
@@ -194,6 +195,12 @@ export const UI_SCENE_LOADERS: Record<string, () => Promise<LoadedUiScene>> = {
       Scene: m.SelectExampleScene,
       code: m.selectExampleCode,
       controls: m.selectExampleControls,
+    })),
+  "select-menu": () =>
+    import("./select-menu-example").then((m) => ({
+      Scene: m.SelectMenuExampleScene,
+      code: m.selectMenuExampleCode,
+      controls: m.selectMenuExampleControls,
     })),
   sheet: () =>
     import("./sheet-example").then((m) => ({

--- a/content/changelog/2026-09-01-select-menu.mdx
+++ b/content/changelog/2026-09-01-select-menu.mdx
@@ -1,0 +1,10 @@
+---
+title: Select Menu
+date: 2026-09-01
+---
+
+### New components
+
+- [Select Menu](/docs/ui/components/select-menu) — a vertical option list where exactly one row is highlighted. A sliding highlight bar and 3px left accent glide between rows as the selection changes, and the row under the indicator can be "clicked" via `selectProgress` — a press dip followed by a settling check mark, mirroring `select`'s press→selected flow. The whole thing is driven entirely from the Remotion timeline. Fully controlled (`selectedIndex`/`state` snap, `useSelectMenuTransition` slides with an optional `clickAt`), with `soft` accent and `solid` primary variants.
+
+<ChangelogPreview name="select-menu" />

--- a/content/docs/ui/components/meta.json
+++ b/content/docs/ui/components/meta.json
@@ -24,6 +24,7 @@
     "radio",
     "resizable",
     "select",
+    "select-menu",
     "skeleton",
     "skeleton-block",
     "slider",

--- a/content/docs/ui/components/select-menu.mdx
+++ b/content/docs/ui/components/select-menu.mdx
@@ -1,0 +1,245 @@
+---
+title: Select Menu
+description: A vertical option list whose highlight slides between selections on the timeline
+component: select-menu
+vibe: clean
+length: 128
+useWhen:
+  - "A vertical single-choice menu where one option is highlighted and the highlight should glide smoothly between options as the selection changes."
+  - "Game-style menus and product-demo navigation where the selection is driven from the Remotion timeline (fully controlled — no real interaction)."
+  - "Replacing stacked radio rows when a sliding highlight + left accent bar reads better than individual dots."
+avoidWhen:
+  - "Options must open a reveal panel — use `select` instead."
+  - "You need grouped actions that open from a trigger button — use `dropdown-menu` instead."
+  - "Options are sequential numbered steps — use `stepper` instead."
+---
+
+<UiComponentPreview name="select-menu" />
+
+A vertical option list where exactly one row is highlighted. The highlight (background + left accent bar) slides smoothly between rows as the selection changes. Its appearance is a pure function of the props you give it — `selectedIndex`/`state` snap, or `style` from `useSelectMenuTransition` slides. Fully controlled: there are no interaction handlers, so it is safe to drive entirely from the Remotion timeline.
+
+<InstallBlock name="select-menu" />
+
+<Note>
+Installing `select-menu` automatically installs the shared `remocn-ui` core (`lib/remocn-ui/`) via `registryDependencies`. You do not need to install it separately.
+</Note>
+
+## States
+
+`SelectMenuState` is:
+
+```ts
+type SelectMenuState = string;
+```
+
+The state is the selected option's value — one of the strings in the `options` array. When the selection changes, the highlight bar slides to the selected row and the label brightens and thickens as the highlight arrives.
+
+## Snap usage (simple path)
+
+Pass `selectedIndex` directly — the component snaps instantly to that visual. Useful for static previews or when you drive selection from your own logic:
+
+```tsx
+import { SelectMenu } from "@/components/remocn/select-menu";
+
+export const Scene = () => (
+  <SelectMenu
+    options={["New Game", "Continue", "Settings", "Quit"]}
+    selectedIndex={1}
+  />
+);
+```
+
+You can also pass the value directly via `state`:
+
+```tsx
+import { SelectMenu } from "@/components/remocn/select-menu";
+
+export const Scene = () => (
+  <SelectMenu
+    options={["New Game", "Continue", "Settings", "Quit"]}
+    state="Settings"
+  />
+);
+```
+
+To drive selection from the timeline with **no animation** (snaps on change), use `useCurrentState`:
+
+```tsx
+import { useCurrentState } from "@/lib/remocn-ui";
+import { SelectMenu } from "@/components/remocn/select-menu";
+
+export const Scene = () => {
+  const state = useCurrentState(
+    [
+      { at: 24, state: "Continue" },
+      { at: 48, state: "Settings" },
+      { at: 72, state: "Quit" },
+    ],
+    "New Game",
+  );
+
+  return (
+    <SelectMenu
+      options={["New Game", "Continue", "Settings", "Quit"]}
+      state={state}
+    />
+  );
+};
+```
+
+Each `at` is a **Sequence-local authored frame**. State persists between steps: `Continue` at frame 24 keeps that row highlighted until `Settings` fires at frame 48. See [Concepts](/docs/ui/concepts) for the full `useCurrentState` API.
+
+## Smooth transitions (opt-in)
+
+Selection changes via `selectedIndex`/`state` snap with no animation. For a smoothly sliding highlight, use `useSelectMenuTransition` from the copied `use-select-menu-transition.ts` file. It reads the frame, interpolates between selection presets, and returns a resolved `SelectMenuStyle` — pass it to the `style` prop:
+
+```tsx
+import { SelectMenu } from "@/components/remocn/select-menu";
+import { useSelectMenuTransition } from "@/components/remocn/use-select-menu-transition";
+
+export const Scene = () => {
+  const style = useSelectMenuTransition([
+    { at: 24, state: "Continue", duration: 14 },
+    { at: 48, state: "Settings", duration: 14 },
+    { at: 72, state: "Quit", duration: 14 },
+  ]);
+
+  return (
+    <SelectMenu
+      style={style}
+      options={["New Game", "Continue", "Settings", "Quit"]}
+    />
+  );
+};
+```
+
+The `duration` field on each step overrides the file's `DEFAULT_DURATION` for that specific transition. To globally tune timing and easing, edit `use-select-menu-transition.ts` directly in your project — that file is yours (shadcn "own your code" philosophy).
+
+`style` takes precedence over `selectedIndex`/`state` when both are provided. So when you drive the menu from the timeline, thread your selection through the **steps** (or a `clickAt`), not through the `selectedIndex` prop — otherwise the prop is silently ignored:
+
+```tsx
+// ✅ The highlight is driven by the timeline.
+const style = useSelectMenuTransition([
+  { at: 24, state: "Continue", duration: 14 },
+  { at: 48, state: "Settings", duration: 14 },
+]);
+
+// ❌ These are ignored whenever `style` is present.
+<SelectMenu style={style} selectedIndex={2} />
+```
+
+## Click / selected effect
+
+The smooth path can also "click" a row — the same press→selected feel as `select`'s items. Add `clickAt` (an authored frame, matching your steps' `at` values) to `useSelectMenuTransition`. When the indicator reaches that frame, the row it rests on presses (a quick scale dip and a brief darkening of the highlight), then settles into the selected state as a check mark fades in on its right edge:
+
+```tsx
+export const Scene = () => {
+  // The highlight arrives at "Settings" at frame 52, rests a beat, then the
+  // press→selected click fires at frame 60 and holds — the check stays until
+  // the next step moves the highlight away.
+  const style = useSelectMenuTransition(
+    [
+      { at: 0, state: "New Game", duration: 12 },
+      { at: 20, state: "Continue", duration: 12 },
+      { at: 40, state: "Settings", duration: 12 },
+      { at: 64, state: "New Game", duration: 16 },
+    ],
+    { clickAt: 60, clickDuration: 14 },
+  );
+
+  return <SelectMenu style={style} />;
+};
+```
+
+The click window is split by two fields: `press` (transient) ramps 0→1 across the first ~40% of the window and back to 0 (the scale dip + darkening), while `selectProgress` (selectedness) rises 0→1 over the release so the check fades in as the row settles. `clickDuration` tunes that window; if you omit it, `DEFAULT_DURATION` is used.
+
+The check appears **only on the row the indicator rests on**: it fades in as that row settles, and disappears the instant the indicator moves away — it is never shown on intermediate rows mid-glide. Coordinate `clickAt` to fire after your arrival step for the best feel.
+
+By default `selectProgress` stays at `1` once the row is selected (the check persists until a later step moves the highlight away). For a selecting cycle that must **restart** cleanly — e.g. a looping preview — pass `hold` (frames to keep the row selected) and `decayDuration` (frames to ease the check back off on that same row), then snap the highlight back to the first option with a hard `duration: 0` step. The tick fades out before the cut, so it is never seen on the first row or anywhere else:
+
+```tsx
+const style = useSelectMenuTransition(
+  [
+    { at: 0, state: "New Game", duration: 12 },
+    { at: 20, state: "Continue", duration: 12 },
+    { at: 40, state: "Settings", duration: 12 },
+    // Instant restart — no glide back through the intermediate rows.
+    // Settle at 52, click at 56 (14f) → selected at 70, hold to 90,
+    // check fades over 90..98, then jump back to New Game.
+    { at: 98, state: "New Game", duration: 0 },
+  ],
+  { clickAt: 56, hold: 20, decayDuration: 8 },
+);
+```
+
+The snap path always renders the selected row fully chosen: `selectMenuStyle` reports `selectProgress: 1` and `press: 0`, so a row chosen via `selectedIndex`/`state` shows its check mark immediately, with no press.
+
+## Sliding highlight and variants
+
+`SelectMenuStyle` carries two animated fields plus the per-row emphasis from the indicator position:
+
+| Field | Meaning |
+|---|---|
+| `indicatorOffset` | Float row index — where the highlight sits. Interpolating it glides the bar between rows with no jump. |
+| `press` | Transient 0..1 press depth of the row under the indicator — a quick scale dip and highlight darkening while it is clicked. `0` at rest. |
+| `selectProgress` | 0..1 selectedness — rises as the release settles the check mark in, holds at `1` while selected, eases back to `0` after a `hold`/`decayDuration` cycle. |
+
+`useSelectMenuTransition` interpolates all three. The same `indicatorOffset` drives per-row label emphasis, so each label brightens and thickens as the highlight arrives and fades as it leaves.
+
+The `variant` prop chooses between two clean looks:
+
+| `variant` | Look | Use case |
+|---|---|---|
+| `"soft"` | Rounded outlined panel; the selected row fills with the theme accent and a primary left accent bar | Product demos, dashboards, tooling |
+| `"solid"` | No outline; the selected row fills with the theme primary color and a contrasting accent bar | Game-style menus, bold CTA moments |
+
+The left accent bar is 3px and rides on the highlighted row's left edge — it is part of the sliding layer, so it glides too.
+
+<PropsTable title="Props"
+  rows={[
+    {
+      name: "options",
+      type: "string[]",
+      default: "[\"New Game\", \"Continue\", \"Settings\", \"Quit\"]",
+      description: "The menu items, top to bottom — one row per entry. Any number of options is supported; the 4-item default is just the demo set.",
+    },
+    {
+      name: "selectedIndex",
+      type: "number",
+      default: "0",
+      description: "Snap path (index). Index of the highlighted row. Selection changes snap — no automatic animation.",
+    },
+    {
+      name: "state",
+      type: "string",
+      description: "Snap path (value). Value of the highlighted row, resolved against options. Ignored when selectedIndex is set.",
+    },
+    {
+      name: "style",
+      type: "SelectMenuStyle",
+      description: "Resolved animated visual (smooth path). Pass an interpolated SelectMenuStyle from useSelectMenuTransition — the sliding highlight (indicatorOffset), the transient press (press), and the press→selected click/selected effect (selectProgress). Takes precedence over selectedIndex/state when provided.",
+    },
+    {
+      name: "variant",
+      type: "\"soft\" | \"solid\"",
+      default: "\"soft\"",
+      description: "Highlight style — soft (accent fill + outline panel) for product demos, solid (primary fill) for game-style menus.",
+    },
+    {
+      name: "align",
+      type: "\"start\" | \"center\" | \"end\"",
+      default: "\"center\"",
+      description: "Aligns the menu within the composition frame.",
+    },
+    {
+      name: "theme",
+      type: "Partial<RemocnTheme>",
+      description: "Per-component theme override. Merges with the active RemocnUIProvider theme and the mode defaults. Must be concrete oklch/hex/rgb values — not CSS custom properties.",
+    },
+    {
+      name: "className",
+      type: "string",
+      description: "Optional className passed to the select-menu element.",
+    },
+  ]}
+/>

--- a/registry/__index__.tsx
+++ b/registry/__index__.tsx
@@ -2488,6 +2488,16 @@ const registry: Record<string, RegistryEntry> = {
         (m) => m.selectItemConfig,
       ),
   },
+  "select-menu": {
+    load: () =>
+      import("@/registry/remocn-ui/select-menu").then((m) => ({
+        default: m.SelectMenu,
+      })),
+    loadConfig: () =>
+      import("@/registry/remocn-ui/select-menu/config").then(
+        (m) => m.selectMenuConfig,
+      ),
+  },
   "dropdown-menu": {
     load: () =>
       import("@/registry/remocn-ui/dropdown-menu").then((m) => ({

--- a/registry/remocn-ui/registry.json
+++ b/registry/remocn-ui/registry.json
@@ -352,6 +352,26 @@
       ]
     },
     {
+      "name": "select-menu",
+      "type": "registry:component",
+      "title": "UI Select Menu",
+      "description": "A vertical option list where exactly one row is highlighted; the highlight bar and left accent slide smoothly between rows. Fully controlled via selectedIndex/state or useSelectMenuTransition.",
+      "dependencies": ["remotion"],
+      "registryDependencies": ["@remocn/remocn-ui"],
+      "files": [
+        {
+          "path": "select-menu/index.tsx",
+          "type": "registry:component",
+          "target": "components/remocn/select-menu.tsx"
+        },
+        {
+          "path": "select-menu/use-select-menu-transition.ts",
+          "type": "registry:component",
+          "target": "components/remocn/use-select-menu-transition.ts"
+        }
+      ]
+    },
+    {
       "name": "dropdown-menu-item",
       "type": "registry:component",
       "title": "UI Dropdown Menu Item",

--- a/registry/remocn-ui/select-menu/__tests__/README.md
+++ b/registry/remocn-ui/select-menu/__tests__/README.md
@@ -1,0 +1,134 @@
+# `select-menu` — verification tests
+
+Pure / deterministic verification for the `select-menu` component
+(`registry/remocn-ui/select-menu/`). The RENDER path needs Remotion's
+`useCurrentFrame()` and cannot run headless, so the render is NOT exercised
+here. This suite covers the pieces that ARE pure: `selectMenuStyle` presets,
+`selectMenuStyleContext` theming, `tweenSelectMenuStyle` interpolation, and
+`selectMenuConfig` control/snippet wiring.
+
+## Animation model — pure snap + opt-in smooth path
+
+SelectMenu ships two complementary paths:
+
+**Snap path** (`selectedIndex?: number` / `state?: string` prop): `SelectMenu` is
+a frame-free pure renderer. The selection is fully controlled. `selectedIndex`
+maps straight to a complete resting visual via the exported pure function
+`selectMenuStyle(selectedIndex, ctx) => SelectMenuStyle`. Selection changes snap
+instantly — no tweening inside the component. `state` is an alias that resolves
+an option value back to an index.
+
+**Smooth path** (`style?: SelectMenuStyle` prop): callers opt in to a smooth
+sliding highlight by passing a pre-interpolated `SelectMenuStyle` to the `style`
+prop. The caller — typically `useSelectMenuTransition` — reads
+`useCurrentFrame()` and calls `useStateTransition` from `core/timeline.ts` to
+compute `{ from, to, progress }`, then blends the two presets via
+`tweenSelectMenuStyle(from, to, t)`. The component itself remains frame-free; it
+simply renders whatever `SelectMenuStyle` it receives.
+
+The three animated fields are:
+
+- `indicatorOffset` — a float row index. Tweening it glides the highlight bar and
+  the left accent between rows with no jump. Per-row label color and weight
+  derive from `proximity = 1 - |i - indicatorOffset|`, exactly like
+  `toggle-group`'s labels, so the emphasis crossfades as the highlight arrives.
+- `press` — transient 0..1 press depth of the row under the indicator. Rises and
+  falls inside the click window (`clickAt` → `clickAt + clickDuration`) and
+  drives a quick scale dip + highlight darkening, like `select-item`'s press
+  state. `0` at rest; snap styles always report `0`.
+- `selectProgress` — 0..1 selectedness. Rises over the release portion of the
+  click window (the check mark fades in on the row's right edge), holds at `1`
+  while selected, and eases back to `0` after a `hold`/`decayDuration` cycle so
+  a selecting loop can restart cleanly. Snap styles report `1` (fully selected).
+  Without a `clickAt`, both `press` and `selectProgress` stay `0` (pure glide,
+  no click effect).
+
+## How to run
+
+The repo uses **Bun**, which has a built-in test runner — runs TypeScript
+natively, no test-framework dep.
+
+```bash
+bun install
+bun test registry/remocn-ui/select-menu/__tests__
+```
+
+`select-menu.test.ts` imports `bun:test` (not `vitest`/`jest`), so no test script
+or framework dep is added to `package.json`.
+
+## What is covered
+
+- **`selectMenuStyle`** — exported pure `(index, ctx) => SelectMenuStyle` map.
+  Asserts an index maps to an equal `indicatorOffset`, index 0 maps to offset 0,
+  negative indices clamp to 0, out-of-range indices clamp to the last row, an
+  unknown state value (index -1 from `options.indexOf`) clamps to 0, and the
+  snap result reports `selectProgress: 1` + `press: 0` (fully selected).
+- **`selectMenuStyleContext`** — exported pure `(options, variant, theme) => ctx`.
+  Asserts the option list is carried through, the soft variant derives its
+  highlight/accent from theme accent + primary, the solid variant fills with
+  `theme.primary` + `theme.primaryForeground`, and the theme `foreground` is
+  carried for the press darkening.
+- **`computeSelectMenuClick`** — exported pure `(frame, clickAt, clickDuration,
+  { hold, decayDuration })` piecewise click timeline. Asserts it is at rest
+  before the window, `press` peaks at the press/release boundary and zeroes by
+  the window end, `selectProgress` rises over the release and stays selected,
+  and — with `hold`/`decayDuration` — eases back to `0` without ever replaying
+  the press.
+- **`tweenSelectMenuStyle`** — exported pure `(a, b, t) => SelectMenuStyle`.
+  Asserts t=0 equals `a`, t=1 equals `b`, t=0.5 is the exact midpoint for
+  `indicatorOffset`, `press`, and `selectProgress`, a same-row tween stays put,
+  and both click fields interpolate linearly.
+- **`selectMenuConfig.controls`** — `selectedIndex` is a `number` control clamped
+  to the option range (0–3, default 1); `variant` is an `enum` control with
+  `soft`/`solid` options.
+- **`selectMenuConfig.snippet`** — REAL pure string builder (high value). Asserts:
+  includes `import { SelectMenu }` from `@/components/remocn/select-menu`; always
+  emits `selectedIndex={n}` (the primary controlled prop); emits non-default
+  `selectedIndex`; omits default-equal `variant="soft"`; emits `variant="solid"`
+  when non-default; includes the default `options`; ends with `/>`.
+
+**SelectMenu render** is a pure `(selectedIndex | state | style) => visual`
+observable only via Remotion render, not unit-tested here.
+
+## Import strategy
+
+`select-menu.test.ts` imports via a mix of **relative paths** and the
+**`@/lib/remocn-ui` tsconfig alias**:
+
+- `../index` — relative, for `SelectMenuStyle`, `selectMenuStyle`,
+  `selectMenuStyleContext`
+- `../use-select-menu-transition` — relative, for `tweenSelectMenuStyle`,
+  `computeSelectMenuClick`, `DEFAULT_DURATION`
+- `../config` — relative, for `selectMenuConfig`
+- `@/lib/remocn-ui` — alias (resolves to `registry/remocn-ui/core/index.ts`),
+  for `defaultLightTheme`
+
+Importing `index.tsx` and `use-select-menu-transition.ts` pulls the `remotion`
+module (and React), but `selectMenuStyle`, `selectMenuStyleContext`,
+`tweenSelectMenuStyle`, and `computeSelectMenuClick` never call
+`useCurrentFrame()` at import time or at call time — they are pure value
+functions. `bun test` resolves tsconfig `paths`, so the alias works without
+additional config.
+
+## Determinism grep checklist (run manually; must print NOTHING)
+
+SelectMenu is frame-free. The component must contain **none** of the following:
+
+```bash
+grep -nE "useCurrentFrame|useState|useEffect|onClick|onChange|addEventListener|Date\.now|Math\.random" \
+  registry/remocn-ui/select-menu/index.tsx
+```
+
+Expected: no output. Any match is a determinism violation.
+
+`use-select-menu-transition.ts` is the CALLER hook that intentionally reads
+`useCurrentFrame()` (via `useStateTransition`). It is not a render component;
+the smooth-path design isolates all frame-reading to the hook, keeping
+`SelectMenu` pure.
+
+Tier-wide sweep:
+
+```bash
+grep -nE "useState|useEffect|onClick|onChange|addEventListener|Date\.now|Math\.random" \
+  registry/remocn-ui/select-menu/index.tsx registry/remocn-ui/core/*.ts
+```

--- a/registry/remocn-ui/select-menu/__tests__/select-menu.test.ts
+++ b/registry/remocn-ui/select-menu/__tests__/select-menu.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "bun:test";
+import { defaultLightTheme } from "@/lib/remocn-ui";
+import { selectMenuConfig } from "../config";
+import {
+  type SelectMenuStyle,
+  selectMenuStyle,
+  selectMenuStyleContext,
+} from "../index";
+import {
+  computeSelectMenuClick,
+  DEFAULT_DURATION,
+  tweenSelectMenuStyle,
+} from "../use-select-menu-transition";
+
+const DEFAULT_OPTIONS = ["New Game", "Continue", "Settings", "Quit"];
+
+const ctx = selectMenuStyleContext(DEFAULT_OPTIONS, "soft", defaultLightTheme);
+const solidCtx = selectMenuStyleContext(
+  DEFAULT_OPTIONS,
+  "solid",
+  defaultLightTheme,
+);
+
+describe("selectMenuStyle", () => {
+  it("maps a selected index to an indicatorOffset of the same value", () => {
+    const s = selectMenuStyle(1, ctx);
+    expect(s.indicatorOffset).toBe(1);
+  });
+
+  it("maps index 0 to offset 0 (first row)", () => {
+    expect(selectMenuStyle(0, ctx).indicatorOffset).toBe(0);
+  });
+
+  it("clamps a negative index to 0", () => {
+    expect(selectMenuStyle(-3, ctx).indicatorOffset).toBe(0);
+  });
+
+  it("clamps an out-of-range index to the last row", () => {
+    const last = DEFAULT_OPTIONS.length - 1;
+    expect(selectMenuStyle(99, ctx).indicatorOffset).toBe(last);
+  });
+
+  it("clamps indexOf(-1) results (unknown state value) to 0", () => {
+    // A state value not present in options maps to index -1 → clamped to 0.
+    expect(
+      selectMenuStyle(DEFAULT_OPTIONS.indexOf("Unknown"), ctx).indicatorOffset,
+    ).toBe(0);
+  });
+
+  it("reports selectProgress 1 and press 0 — selected fully, no press", () => {
+    expect(selectMenuStyle(2, ctx).selectProgress).toBe(1);
+    expect(selectMenuStyle(2, ctx).press).toBe(0);
+    expect(selectMenuStyle(0, solidCtx).selectProgress).toBe(1);
+  });
+});
+
+describe("selectMenuStyleContext", () => {
+  it("carries the option list and a default first option", () => {
+    expect(ctx.options).toEqual(DEFAULT_OPTIONS);
+    expect(ctx.options[0]).toBe("New Game");
+  });
+
+  it("soft variant uses accent-based highlight with a primary accent bar", () => {
+    expect(ctx.variant).toBe("soft");
+    expect(ctx.highlightBg).toBeTypeOf("string");
+    expect(typeof ctx.accent).toBe("string");
+    // highlight (accent) and inactive label are both non-empty oklch strings
+    expect(ctx.highlightBg.length).toBeGreaterThan(0);
+    expect(ctx.inactiveFg.length).toBeGreaterThan(0);
+  });
+
+  it("solid variant uses primary background and primaryForeground accent", () => {
+    expect(solidCtx.variant).toBe("solid");
+    expect(solidCtx.highlightBg).toBe(defaultLightTheme.primary);
+    expect(solidCtx.accent).toBe(defaultLightTheme.primaryForeground);
+  });
+
+  it("inactive foreground is non-empty for both variants", () => {
+    expect(ctx.inactiveFg.length).toBeGreaterThan(0);
+    expect(solidCtx.inactiveFg.length).toBeGreaterThan(0);
+  });
+
+  it("carries the theme foreground for the press darkening", () => {
+    expect(ctx.foreground).toBe(defaultLightTheme.foreground);
+  });
+});
+
+describe("computeSelectMenuClick", () => {
+  it("is fully at rest before the click window", () => {
+    const r = computeSelectMenuClick(0, 60);
+    expect(r.press).toBe(0);
+    expect(r.selectProgress).toBe(0);
+  });
+
+  it("presses over the first portion and releases by the window end", () => {
+    // With dur 10, pressEnd = 4.
+    const half = computeSelectMenuClick(50, 48, 10); // t = 2 → mid-press
+    expect(half.press).toBeCloseTo(0.5, 10);
+    expect(half.selectProgress).toBe(0); // check not risen yet
+    expect(computeSelectMenuClick(48 + 4, 48, 10).press).toBeCloseTo(1, 10);
+    expect(computeSelectMenuClick(48 + 10, 48, 10).press).toBe(0);
+  });
+
+  it("rises selectProgress during the release and persists once selected", () => {
+    const r = computeSelectMenuClick(48 + 10 + 30, 48, 10); // long after
+    expect(r.selectProgress).toBe(1);
+  });
+
+  it("keeps selected persistent when no hold is configured", () => {
+    const late = computeSelectMenuClick(60 + 200, 60, DEFAULT_DURATION);
+    expect(late.press).toBe(0);
+    expect(late.selectProgress).toBe(1);
+  });
+
+  it("decays selectProgress back to 0 after the hold", () => {
+    // clickAt=60, dur=10, hold=5, decay=10 → decayStart at 75.
+    const opts = { hold: 5, decayDuration: 10 };
+    const atHoldEnd = computeSelectMenuClick(75, 60, 10, opts); // t=15
+    expect(atHoldEnd.selectProgress).toBe(1);
+    expect(atHoldEnd.press).toBe(0);
+    const midDecay = computeSelectMenuClick(80, 60, 10, opts); // t=20, decay 0.5
+    expect(midDecay.selectProgress).toBeCloseTo(0.5, 10);
+    const fullyDecayed = computeSelectMenuClick(85 + 40, 60, 10, opts);
+    expect(fullyDecayed.selectProgress).toBe(0);
+    // Decay never replays the press.
+    expect(fullyDecayed.press).toBe(0);
+    expect(midDecay.press).toBe(0);
+  });
+});
+
+describe("tweenSelectMenuStyle", () => {
+  it("t=0 equals `a`", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 0,
+      press: 0,
+      selectProgress: 0,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 3,
+      press: 1,
+      selectProgress: 1,
+    };
+    const r = tweenSelectMenuStyle(a, b, 0);
+    expect(r.indicatorOffset).toBeCloseTo(0, 10);
+    expect(r.press).toBeCloseTo(0, 10);
+    expect(r.selectProgress).toBeCloseTo(0, 10);
+  });
+
+  it("t=1 equals `b`", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 0,
+      press: 0,
+      selectProgress: 0,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 3,
+      press: 1,
+      selectProgress: 1,
+    };
+    const r = tweenSelectMenuStyle(a, b, 1);
+    expect(r.indicatorOffset).toBeCloseTo(3, 10);
+    expect(r.press).toBeCloseTo(1, 10);
+    expect(r.selectProgress).toBeCloseTo(1, 10);
+  });
+
+  it("t=0.5 is the exact midpoint (0 → 3 gives 1.5)", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 0,
+      press: 0,
+      selectProgress: 0,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 3,
+      press: 1,
+      selectProgress: 1,
+    };
+    const r = tweenSelectMenuStyle(a, b, 0.5);
+    expect(r.indicatorOffset).toBeCloseTo(1.5, 10);
+    expect(r.press).toBeCloseTo(0.5, 10);
+    expect(r.selectProgress).toBeCloseTo(0.5, 10);
+  });
+
+  it("t=0.5 between 1 and 2 gives 1.5 (adjacent rows)", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 1,
+      press: 0,
+      selectProgress: 0,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 2,
+      press: 0,
+      selectProgress: 1,
+    };
+    expect(tweenSelectMenuStyle(a, b, 0.5).indicatorOffset).toBeCloseTo(
+      1.5,
+      10,
+    );
+  });
+
+  it("handles a same-row tween (both offsets equal)", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 2,
+      press: 0.3,
+      selectProgress: 0.6,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 2,
+      press: 0.3,
+      selectProgress: 0.6,
+    };
+    const r = tweenSelectMenuStyle(a, b, 0.37);
+    expect(r.indicatorOffset).toBeCloseTo(2, 10);
+    expect(r.press).toBeCloseTo(0.3, 10);
+    expect(r.selectProgress).toBeCloseTo(0.6, 10);
+  });
+
+  it("interpolates press and selectProgress linearly", () => {
+    const a: SelectMenuStyle = {
+      indicatorOffset: 0,
+      press: 0,
+      selectProgress: 0,
+    };
+    const b: SelectMenuStyle = {
+      indicatorOffset: 0,
+      press: 1,
+      selectProgress: 1,
+    };
+    expect(tweenSelectMenuStyle(a, b, 0.25).press).toBeCloseTo(0.25, 10);
+    expect(tweenSelectMenuStyle(a, b, 0.75).selectProgress).toBeCloseTo(
+      0.75,
+      10,
+    );
+  });
+});
+
+describe("selectMenuConfig.controls", () => {
+  it("selectedIndex is a number control clamped to the option range", () => {
+    const ctrl = selectMenuConfig.controls.selectedIndex;
+    expect(ctrl.type).toBe("number");
+    if (ctrl.type !== "number") throw new Error("expected number control");
+    expect(ctrl.min).toBe(0);
+    expect(ctrl.max).toBe(3);
+    expect(ctrl.default).toBe(1);
+  });
+
+  it("variant is an enum control with soft/solid options", () => {
+    const ctrl = selectMenuConfig.controls.variant;
+    expect(ctrl.type).toBe("enum");
+    if (ctrl.type !== "enum") throw new Error("expected enum control");
+    expect(Object.keys(ctrl.variants).sort()).toEqual(["soft", "solid"]);
+    expect(ctrl.default).toBe("soft");
+  });
+});
+
+describe("selectMenuConfig.snippet", () => {
+  type SnippetValues = { selectedIndex?: number; variant?: string };
+
+  const snippet = (values: SnippetValues): string =>
+    selectMenuConfig.snippet(values as Record<string, unknown>);
+
+  it("includes the import line from the install path", () => {
+    const out = snippet({ selectedIndex: 1 });
+    expect(out).toContain("import { SelectMenu }");
+    expect(out).toContain('from "@/components/remocn/select-menu"');
+  });
+
+  it("emits selectedIndex always (primary controlled prop)", () => {
+    const out = snippet({ selectedIndex: 1 });
+    expect(out).toContain("selectedIndex={1}");
+  });
+
+  it("emits a non-default selectedIndex", () => {
+    expect(snippet({ selectedIndex: 3 })).toContain("selectedIndex={3}");
+  });
+
+  it("omits a default-equal variant (soft)", () => {
+    expect(snippet({ selectedIndex: 1, variant: "soft" })).not.toContain(
+      "variant=",
+    );
+  });
+
+  it("emits a non-default variant (solid)", () => {
+    expect(snippet({ selectedIndex: 1, variant: "solid" })).toContain(
+      'variant="solid"',
+    );
+  });
+
+  it("includes the options array with the default values", () => {
+    const out = snippet({ selectedIndex: 0 });
+    expect(out).toContain("New Game");
+    expect(out).toContain("Quit");
+  });
+
+  it("ends with a self-closing />", () => {
+    expect(snippet({ selectedIndex: 2 }).trimEnd().endsWith("/>")).toBe(true);
+  });
+});

--- a/registry/remocn-ui/select-menu/config.ts
+++ b/registry/remocn-ui/select-menu/config.ts
@@ -1,0 +1,50 @@
+import { type ComponentConfig, FPS, H, W } from "@/lib/customizer-config";
+
+const DEFAULT_OPTIONS = ["New Game", "Continue", "Settings", "Quit"];
+
+export const selectMenuConfig: ComponentConfig = {
+  componentName: "SelectMenu",
+  importPath: "@/components/remocn/select-menu",
+  controls: {
+    selectedIndex: {
+      type: "number",
+      min: 0,
+      max: 3,
+      step: 1,
+      default: 1,
+      description:
+        "Selected index (0–3 is the demo's 4 options; the component accepts any number)",
+      hiddenFromList: false,
+    },
+    variant: {
+      type: "enum",
+      default: "soft",
+      variants: {
+        soft: {},
+        solid: {},
+      },
+      description: "Variant",
+    },
+  },
+  dimensions: { width: 300, height: 202 },
+  durationInFrames: 128,
+  fps: FPS,
+  compositionWidth: W,
+  compositionHeight: H,
+  previewBackdrop: { type: "color", value: "oklch(1 0 0)" },
+  snippet: (values) => {
+    const selectedIndex = values.selectedIndex as number | undefined;
+    const variant = values.variant as string | undefined;
+
+    const props: string[] = [`  selectedIndex={${selectedIndex ?? 1}}`];
+    if (variant !== undefined && variant !== "soft")
+      props.push(`  variant="${variant}"`);
+
+    return `import { SelectMenu } from "@/components/remocn/select-menu";
+
+<SelectMenu
+  options={${JSON.stringify(DEFAULT_OPTIONS)}}
+${props.join("\n")}
+/>`;
+  },
+};

--- a/registry/remocn-ui/select-menu/config.ts
+++ b/registry/remocn-ui/select-menu/config.ts
@@ -12,8 +12,8 @@ export const selectMenuConfig: ComponentConfig = {
       max: 3,
       step: 1,
       default: 1,
-      description:
-        "Selected index (0–3 is the demo's 4 options; the component accepts any number)",
+      // description:
+      //   "Selected index (0–3 is the demo's 4 options; the component accepts any number)",
       hiddenFromList: false,
     },
     variant: {

--- a/registry/remocn-ui/select-menu/index.tsx
+++ b/registry/remocn-ui/select-menu/index.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { mixOklch, type RemocnTheme, useRemocnTheme } from "@/lib/remocn-ui";
+
+export type SelectMenuState = string;
+
+export type SelectMenuVariant = "soft" | "solid";
+
+export interface SelectMenuProps {
+  options?: string[];
+  selectedIndex?: number;
+  state?: SelectMenuState;
+  style?: SelectMenuStyle;
+  variant?: SelectMenuVariant;
+  align?: "start" | "center" | "end";
+  theme?: Partial<RemocnTheme>;
+  className?: string;
+}
+
+const WIDTH = 300;
+const PAD = 4;
+const ROW_HEIGHT = 44;
+const ROW_GAP = 6;
+const ACCENT_BAR = 3;
+const LABEL_L_PAD = 18;
+const CHECK_SIZE = 18;
+const PRESS_DIP = 0.03;
+const PRESS_TINT = 0.05;
+
+function justify(align: "start" | "center" | "end"): string {
+  return align === "start"
+    ? "flex-start"
+    : align === "end"
+      ? "flex-end"
+      : "center";
+}
+
+function clamp01(t: number): number {
+  return Math.max(0, Math.min(1, t));
+}
+
+const DEFAULT_OPTIONS: string[] = ["New Game", "Continue", "Settings", "Quit"];
+
+export interface SelectMenuStyle {
+  indicatorOffset: number;
+  press: number;
+  selectProgress: number;
+}
+
+export interface SelectMenuStyleContext {
+  options: string[];
+  variant: SelectMenuVariant;
+  highlightBg: string;
+  highlightFg: string;
+  accent: string;
+  inactiveFg: string;
+  border: string;
+  radius: number;
+  foreground: string;
+}
+
+export function selectMenuStyleContext(
+  options: string[],
+  variant: SelectMenuVariant,
+  theme: RemocnTheme,
+): SelectMenuStyleContext {
+  const soft = variant === "soft";
+  return {
+    options,
+    variant,
+    highlightBg: soft ? theme.accent : theme.primary,
+    highlightFg: soft ? theme.foreground : theme.primaryForeground,
+    accent: soft ? theme.primary : theme.primaryForeground,
+    inactiveFg: theme.mutedForeground,
+    border: theme.border,
+    radius: theme.radius,
+    foreground: theme.foreground,
+  };
+}
+
+export function selectMenuStyle(
+  selectedIndex: number,
+  ctx: SelectMenuStyleContext,
+): SelectMenuStyle {
+  return {
+    indicatorOffset: Math.max(
+      0,
+      Math.min(ctx.options.length - 1, selectedIndex),
+    ),
+    press: 0,
+    selectProgress: 1,
+  };
+}
+
+export function SelectMenu({
+  options = DEFAULT_OPTIONS,
+  selectedIndex,
+  state,
+  style,
+  variant = "soft",
+  align = "center",
+  theme: themeOverride,
+  className,
+}: SelectMenuProps) {
+  const theme = useRemocnTheme(themeOverride, "light");
+  const ctx = selectMenuStyleContext(options, variant, theme);
+
+  const snapIndex =
+    selectedIndex !== undefined
+      ? selectedIndex
+      : state !== undefined
+        ? options.indexOf(state)
+        : 0;
+  const v = style ?? selectMenuStyle(snapIndex, ctx);
+
+  const pressDepth = clamp01(v.press ?? 0);
+  const selectProgress = clamp01(v.selectProgress ?? 0);
+
+  const listHeight =
+    PAD * 2 + options.length * ROW_HEIGHT + (options.length - 1) * ROW_GAP;
+  const step = ROW_HEIGHT + ROW_GAP;
+
+  const highlightTop = PAD + v.indicatorOffset * step;
+  const highlightInset = PAD;
+
+  const isSoft = ctx.variant === "soft";
+  const highlightBackground = mixOklch(
+    ctx.highlightBg,
+    ctx.foreground,
+    PRESS_TINT * pressDepth,
+  );
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: justify(align),
+        background: "transparent",
+        fontFamily:
+          "var(--font-geist-sans), -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: WIDTH,
+          height: listHeight,
+          boxSizing: "border-box",
+        }}
+      >
+        {/* Outer track — an outline panel for the soft product look. */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            borderRadius: ctx.radius,
+            border: isSoft ? `1px solid ${ctx.border}` : "none",
+          }}
+        />
+        {/* Sliding highlight: background + left accent bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: highlightTop,
+            left: highlightInset,
+            width: WIDTH - highlightInset * 2,
+            height: ROW_HEIGHT,
+            boxSizing: "border-box",
+            borderRadius: Math.max(2, ctx.radius - 2),
+            background: highlightBackground,
+            border: isSoft ? `1px solid ${ctx.border}` : "none",
+            overflow: "hidden",
+          }}
+        >
+          {/* Left accent bar */}
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: ACCENT_BAR,
+              background: ctx.accent,
+            }}
+          />
+        </div>
+
+        {/* Rows */}
+        {options.map((option, i) => {
+
+          const proximity = Math.max(0, 1 - Math.abs(i - v.indicatorOffset));
+          const onRow = proximity >= 0.65 ? 1 : 0;
+          const scale = 1 - PRESS_DIP * pressDepth * proximity;
+          const proxGate = clamp01((proximity - 0.85) / 0.15);
+          const checkOpacity = selectProgress * proxGate;
+          return (
+            <div
+              key={option}
+              style={{
+                position: "absolute",
+                top: PAD + i * step,
+                left: highlightInset,
+                width: WIDTH - highlightInset * 2,
+                height: ROW_HEIGHT,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                paddingLeft: LABEL_L_PAD,
+                paddingRight: 12,
+                boxSizing: "border-box",
+                transform: `scale(${scale})`,
+                transformOrigin: "center",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 15,
+                  fontWeight: onRow ? 600 : 500,
+                  letterSpacing: "0.01em",
+                  color: mixOklch(ctx.inactiveFg, ctx.highlightFg, proximity),
+                }}
+              >
+                {option}
+              </span>
+              <svg
+                width={CHECK_SIZE}
+                height={CHECK_SIZE}
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden
+                style={{ flexShrink: 0, opacity: checkOpacity }}
+              >
+                <path
+                  d="M5 12.5l4.5 4.5L19 7"
+                  stroke={ctx.highlightFg}
+                  strokeWidth="2.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/registry/remocn-ui/select-menu/use-select-menu-transition.ts
+++ b/registry/remocn-ui/select-menu/use-select-menu-transition.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCurrentFrame } from "remotion";
+import {
+  type SelectMenuState,
+  type SelectMenuStyle,
+  type SelectMenuVariant,
+  selectMenuStyle,
+  selectMenuStyleContext,
+} from "@/components/remocn/select-menu";
+import {
+  clamp01,
+  easings,
+  type RemocnTheme,
+  type Step,
+  useRemocnTheme,
+  useStateTransition,
+} from "@/lib/remocn-ui";
+
+const DEFAULT_OPTIONS = ["New Game", "Continue", "Settings", "Quit"];
+
+export const DEFAULT_DURATION = 14;
+export const DEFAULT_DECAY_DURATION = 8;
+export const PRESS_PORTION = 0.4;
+
+export function tweenSelectMenuStyle(
+  a: SelectMenuStyle,
+  b: SelectMenuStyle,
+  t: number,
+): SelectMenuStyle {
+  return {
+    indicatorOffset:
+      a.indicatorOffset + (b.indicatorOffset - a.indicatorOffset) * t,
+    press: a.press + (b.press - a.press) * t,
+    selectProgress:
+      a.selectProgress + (b.selectProgress - a.selectProgress) * t,
+  };
+}
+
+export interface SelectMenuClickOptions {
+  hold?: number;
+  decayDuration?: number;
+}
+
+export function computeSelectMenuClick(
+  frame: number,
+  clickAt: number,
+  clickDuration = DEFAULT_DURATION,
+  opts: SelectMenuClickOptions = {},
+): Pick<SelectMenuStyle, "press" | "selectProgress"> {
+  const t = frame - clickAt;
+  const dur = Math.max(1, clickDuration);
+  const pressEnd = dur * PRESS_PORTION;
+
+  const press =
+    t <= 0 || t >= dur
+      ? 0
+      : t < pressEnd
+        ? clamp01(t / pressEnd)
+        : clamp01(1 - (t - pressEnd) / Math.max(1, dur - pressEnd));
+
+  const riseStart = pressEnd;
+  const rise = clamp01((t - riseStart) / Math.max(1, dur - riseStart));
+
+  let selectProgress = rise;
+  if (opts.hold !== undefined) {
+    const decayStart = dur + opts.hold;
+    const decay = clamp01(
+      (t - decayStart) /
+        Math.max(1, opts.decayDuration ?? DEFAULT_DECAY_DURATION),
+    );
+    selectProgress = clamp01(rise - decay);
+  }
+
+  return { press, selectProgress };
+}
+
+export interface SelectMenuTransitionOptions extends SelectMenuClickOptions {
+  options?: string[];
+  variant?: SelectMenuVariant;
+  theme?: Partial<RemocnTheme>;
+  mode?: "light" | "dark";
+  speed?: number;
+  defaultDuration?: number;
+  clickAt?: number;
+  clickDuration?: number;
+}
+
+export function useSelectMenuTransition(
+  steps: Step<SelectMenuState>[],
+  opts: SelectMenuTransitionOptions = {},
+): SelectMenuStyle {
+  const {
+    options = DEFAULT_OPTIONS,
+    variant = "soft",
+    theme: themeOverride,
+    mode,
+    speed = 1,
+    defaultDuration = DEFAULT_DURATION,
+    clickAt,
+    clickDuration = DEFAULT_DURATION,
+    hold,
+    decayDuration,
+  } = opts;
+  const theme = useRemocnTheme(themeOverride, mode);
+  const ctx = selectMenuStyleContext(options, variant, theme);
+  const { from, to, progress } = useStateTransition(
+    steps,
+    options[0] ?? "",
+    speed,
+    defaultDuration,
+  );
+  const t = easings.out(progress);
+  const style = tweenSelectMenuStyle(
+    selectMenuStyle(options.indexOf(from), ctx),
+    selectMenuStyle(options.indexOf(to), ctx),
+    t,
+  );
+
+  const frame = useCurrentFrame() * speed;
+  const click =
+    clickAt === undefined
+      ? { press: 0, selectProgress: 0 }
+      : computeSelectMenuClick(frame, clickAt, clickDuration, {
+          hold,
+          decayDuration,
+        });
+
+  return { ...style, ...click };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,6 +71,9 @@
       "@/components/remocn/use-select-item-transition": [
         "./registry/remocn-ui/select-item/use-select-item-transition.ts"
       ],
+      "@/components/remocn/use-select-menu-transition": [
+        "./registry/remocn-ui/select-menu/use-select-menu-transition.ts"
+      ],
       "@/components/remocn/use-slider-transition": [
         "./registry/remocn-ui/slider/use-slider-transition.ts"
       ],


### PR DESCRIPTION
Adds a simple vertical select-menu component for Remotion.

- Smooth highlight transition
- Fully controlled by `selectedIndex` (timeline-friendly)
- Useful for game style menus, choice screens, and product demos

This can also serve as a base for building more interactive list/menu components in the future.

<img width="1920" height="1080" alt="select-menu" src="https://github.com/user-attachments/assets/37138fac-844a-40cb-b277-ca1922fc6eb5" />
