### PR TITLE
Generate README sponsors table from landing sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,25 @@ When a browser tab opens with an empty video player, you're ready. Pick a [guide
 remocn is free and MIT-licensed. These sponsors keep the registry growing and the renders fast.
 
 <!-- sponsors:start -->
-<p align="center">
-  <a href="https://neon.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/neon-dark.svg" /><img src="https://remocn.dev/sponsors/neon.svg" alt="Neon" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://www.launchfa.st"><img src="https://remocn.dev/sponsors/launchfast.png" alt="LaunchFast" height="32" /></a>&nbsp;&nbsp;
-  <a href="https://ui.aceternity.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/aceternity-dark.svg" /><img src="https://remocn.dev/sponsors/aceternity.svg" alt="Aceternity UI" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://vidrush.ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/vidrush-dark.png" /><img src="https://remocn.dev/sponsors/vidrush.png" alt="VidRush" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://21st.dev"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/21st-dark.svg" /><img src="https://remocn.dev/sponsors/21st.svg" alt="21st.dev" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://pro.reactbits.dev"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/reactbits-dark.svg" /><img src="https://remocn.dev/sponsors/reactbits.svg" alt="React Bits" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://reui.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/reui-dark.svg" /><img src="https://remocn.dev/sponsors/reui.svg" alt="ReUI" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://shadcnblocks.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/shadcnblocks-dark.svg" /><img src="https://remocn.dev/sponsors/shadcnblocks.svg" alt="Shadcnblocks.com" height="32" /></picture></a>&nbsp;&nbsp;
-  <a href="https://shadcnuikit.com"><img src="https://remocn.dev/sponsors/shadcnuikit.png" alt="Shadcn UI Kit" height="32" /></a>&nbsp;&nbsp;
-</p>
+<table align="center">
+  <tbody>
+    <tr>
+      <td colspan="15" width="850" align="center"><a href="https://neon.com/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/neon-dark.svg" /><img src="https://remocn.dev/sponsors/neon.svg" alt="Neon" height="48" align="middle" /></picture></a></td>
+    </tr>
+    <tr>
+      <td colspan="5" width="283" align="center"><a href="https://www.launchfa.st/"><img src="https://remocn.dev/sponsors/launchfast.png" alt="LaunchFast" height="40" align="middle" /> <b>LaunchFast</b></a></td>
+      <td colspan="5" width="283" align="center"><a href="https://ui.aceternity.com/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/aceternity-dark.svg" /><img src="https://remocn.dev/sponsors/aceternity.svg" alt="Aceternity UI" height="40" align="middle" /></picture> <b>Aceternity UI</b></a></td>
+      <td colspan="5" width="283" align="center"><a href="https://vidrush.ai/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/vidrush-dark.png" /><img src="https://remocn.dev/sponsors/vidrush.png" alt="VidRush" height="40" align="middle" /></picture></a></td>
+    </tr>
+    <tr>
+      <td colspan="3" width="170" align="center"><a href="https://21st.dev/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/21st-dark.svg" /><img src="https://remocn.dev/sponsors/21st.svg" alt="21st.dev" height="32" align="middle" /></picture></a></td>
+      <td colspan="3" width="170" align="center"><a href="https://pro.reactbits.dev/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/reactbits-dark.svg" /><img src="https://remocn.dev/sponsors/reactbits.svg" alt="React Bits" height="32" align="middle" /></picture></a></td>
+      <td colspan="3" width="170" align="center"><a href="https://reui.io/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/reui-dark.svg" /><img src="https://remocn.dev/sponsors/reui.svg" alt="ReUI" height="32" align="middle" /></picture></a></td>
+      <td colspan="3" width="170" align="center"><a href="https://shadcnblocks.com/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://remocn.dev/sponsors/shadcnblocks-dark.svg" /><img src="https://remocn.dev/sponsors/shadcnblocks.svg" alt="Shadcnblocks.com" height="32" align="middle" /></picture></a></td>
+      <td colspan="3" width="170" align="center"><a href="https://shadcnuikit.com/"><img src="https://remocn.dev/sponsors/shadcnuikit.png" alt="Shadcn UI Kit" height="32" align="middle" /> <b>Shadcn UI Kit</b></a></td>
+    </tr>
+  </tbody>
+</table>
 <!-- sponsors:end -->
 
 [Become a sponsor](https://remocn.dev/sponsors) to get your logo on the landing page, in the docs sidebar and here.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "next start",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
+    "sponsors:readme": "bun scripts/sponsors-readme.mts",
     "lint": "biome check",
     "format": "biome format --write",
     "registry:build": "shadcn build --output registry-artifacts && bun scripts/build-elements.mts && biome format --write registry-artifacts",

--- a/scripts/sponsors-readme.mts
+++ b/scripts/sponsors-readme.mts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  getLandingSponsors,
+  type Sponsor,
+  type SponsorTier,
+} from "../config/sponsors";
+
+const README = join(import.meta.dirname, "..", "README.md");
+const PUBLIC = join(import.meta.dirname, "..", "public");
+const CDN = "https://remocn.dev";
+const START = "<!-- sponsors:start -->";
+const END = "<!-- sponsors:end -->";
+
+const COLUMNS = 15;
+const TABLE_WIDTH = 850;
+
+const TIER_LAYOUT: Record<SponsorTier, { perRow: number; height: number }> = {
+  legendary: { perRow: 1, height: 48 },
+  featured: { perRow: 3, height: 40 },
+  partner: { perRow: 5, height: 32 },
+  builder: { perRow: 5, height: 32 },
+};
+
+const TIER_ORDER: SponsorTier[] = [
+  "legendary",
+  "featured",
+  "partner",
+  "builder",
+];
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const rows: T[][] = [];
+  for (let i = 0; i < items.length; i += size)
+    rows.push(items.slice(i, i + size));
+  return rows;
+}
+
+function darkTwin(logoUrl: string): string | null {
+  const dark = logoUrl.replace(/(\.[a-z]+)$/, "-dark$1");
+  return existsSync(join(PUBLIC, dark)) ? dark : null;
+}
+
+function logo(sponsor: Sponsor, height: number): string {
+  const img = `<img src="${CDN}${sponsor.logoUrl}" alt="${sponsor.name}" height="${height}" align="middle" />`;
+  const dark = darkTwin(sponsor.logoUrl);
+  const picture = dark
+    ? `<picture><source media="(prefers-color-scheme: dark)" srcset="${CDN}${dark}" />${img}</picture>`
+    : img;
+  const label = sponsor.displayName ? ` <b>${sponsor.displayName}</b>` : "";
+  const href = sponsor.website.split("?")[0];
+  return `<a href="${href}">${picture}${label}</a>`;
+}
+
+function cell(sponsor: Sponsor, colspan: number, height: number): string {
+  const width = Math.round((TABLE_WIDTH * colspan) / COLUMNS);
+  return `      <td colspan="${colspan}" width="${width}" align="center">${logo(sponsor, height)}</td>`;
+}
+
+function render(sponsors: Sponsor[]): string {
+  const rows = TIER_ORDER.flatMap((tier) => {
+    const { perRow, height } = TIER_LAYOUT[tier];
+    const base = COLUMNS / perRow;
+    return chunk(
+      sponsors.filter((s) => s.tier === tier),
+      perRow,
+    ).map((row) => {
+      const colspan = COLUMNS % row.length === 0 ? COLUMNS / row.length : base;
+      return [
+        "    <tr>",
+        ...row.map((s) => cell(s, colspan, height)),
+        "    </tr>",
+      ].join("\n");
+    });
+  });
+  return [
+    '<table align="center">',
+    "  <tbody>",
+    ...rows,
+    "  </tbody>",
+    "</table>",
+  ].join("\n");
+}
+
+const readme = readFileSync(README, "utf8");
+const start = readme.indexOf(START);
+const end = readme.indexOf(END);
+if (start === -1 || end === -1) {
+  throw new Error(`README.md is missing the ${START} / ${END} markers`);
+}
+
+const block = `${START}\n${render(getLandingSponsors())}\n${END}`;
+writeFileSync(
+  README,
+  readme.slice(0, start) + block + readme.slice(end + END.length),
+);
+console.log(
+  `README sponsors block updated (${getLandingSponsors().length} sponsors)`,
+);


### PR DESCRIPTION
## Summary
Follow-up to #279: the README sponsors block is now a generated table instead of a hand-written inline row.

- `scripts/sponsors-readme.mts` rewrites the block between `<!-- sponsors:start/end -->` from `getLandingSponsors()`: one table row per tier, equal-width cells via `colspan` on a 15-column grid.
- Tier is expressed through logo height (legendary 48, featured 40, partner 32), no group headings.
- Icon-only logos get their `displayName` as a label (LaunchFast, Aceternity UI, Shadcn UI Kit).
- `-dark` twins in `public/sponsors` are picked up automatically and served through `<picture>`.
- `bun run sponsors:readme`; the `add-sponsor` skill now points to it.

## Test plan
- [ ] README on GitHub, light and dark: three rows, cells aligned, labels next to icon logos
- [ ] `bun run sponsors:readme` is idempotent on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M91iYp2W3NNrPybdDLYmf2