### PR TITLE
Fix CI build on fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
         env:
-          SHOWCASES_API_URL: ${{ vars.SHOWCASES_API_URL }}
+          SHOWCASES_API_URL: ${{ vars.SHOWCASES_API_URL || 'https://manager.remocn.dev' }}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -5,9 +5,9 @@ import { DocsShell } from "@/components/docs/docs-shell";
 import { DocsTabsBar } from "@/components/docs/docs-tabs-bar";
 import { splitDocsTree } from "@/lib/docs-tabs";
 import { withNewBadges } from "@/lib/with-new-badges";
+import remocnRegistry from "@/registry/remocn/registry.json";
 import iconsRegistry from "@/registry/remocn-icons/registry.json";
 import uiRegistry from "@/registry/remocn-ui/registry.json";
-import remocnRegistry from "@/registry/remocn/registry.json";
 import { source } from "@/source";
 
 const componentCount = [remocnRegistry, uiRegistry, iconsRegistry]

--- a/app/lab/header/header-lab.tsx
+++ b/app/lab/header/header-lab.tsx
@@ -232,10 +232,7 @@ function LabHeader({ cfg, active }: { cfg: LabConfig; active: boolean }) {
   );
 
   return (
-    <header
-      className="fixed top-0 left-0 z-40"
-      style={{ right: PANEL_WIDTH }}
-    >
+    <header className="fixed top-0 left-0 z-40" style={{ right: PANEL_WIDTH }}>
       {island ? (
         <div
           className="section"
@@ -387,11 +384,18 @@ export function HeaderLab() {
           </div>
         </div>
 
-        <label className="mt-4 flex h-9 items-center justify-between rounded-xl control-surface px-3 text-sm">
+        <label
+          htmlFor="force-scrolled"
+          className="mt-4 flex h-9 items-center justify-between rounded-xl control-surface px-3 text-sm"
+        >
           <span className="font-medium text-muted-foreground">
             Force scrolled state
           </span>
-          <Switch checked={forceScrolled} onCheckedChange={setForceScrolled} />
+          <Switch
+            id="force-scrolled"
+            checked={forceScrolled}
+            onCheckedChange={setForceScrolled}
+          />
         </label>
 
         <div className="mt-3 [&>div]:grid-cols-1!">

--- a/components/docs/docs-shell.tsx
+++ b/components/docs/docs-shell.tsx
@@ -57,9 +57,16 @@ export function DocsShell({
   children: ReactNode;
 }) {
   const searchTriggerFull = useMemo(() => {
-    function SearchTriggerFull({ hideIfDisabled }: { hideIfDisabled?: boolean }) {
+    function SearchTriggerFull({
+      hideIfDisabled,
+    }: {
+      hideIfDisabled?: boolean;
+    }) {
       return (
-        <DocsSearchTrigger count={componentCount} hideIfDisabled={hideIfDisabled} />
+        <DocsSearchTrigger
+          count={componentCount}
+          hideIfDisabled={hideIfDisabled}
+        />
       );
     }
     return SearchTriggerFull;


### PR DESCRIPTION
## Problem

CI's `build` job fails on every pull request opened from a fork — most recently [#277](https://github.com/Remocn/remocn/pull/277), [run 33502305709](https://github.com/Remocn/remocn/actions/runs/33502305709/job/100314172047):

```
SHOWCASES_API_URL is not set. ...
> Build error occurred
Error: Failed to collect page data for /showcases/[slug]
```

GitHub does not pass the `vars` context to workflows triggered by `pull_request` from a fork ([community discussion #44322](https://github.com/orgs/community/discussions/44322)) — the same rule as for secrets, just undocumented. So `vars.SHOWCASES_API_URL` resolves to an empty string, `apiBase()` in `lib/showcases.ts` throws, and Next dies collecting page data for `/showcases/[slug]`. PRs from branches inside the repo are unaffected, which is why this only shows up on external contributions.

## Fix

The manager URL is public, not a secret, so the `build` job carries it as a literal fallback. `vars` still wins wherever it is populated (empty string is falsy in GitHub expressions), so nothing changes for internal PRs or for pushes to `main`/`staging`.

Alternatives considered and rejected:

- Skipping `build` on fork PRs — external contributions are exactly the ones that most need the build checked.
- Making `getShowcases()` tolerate a missing base — that guard exists to catch a misconfigured Coolify deployment, and softening it would let a broken showcases section ship silently.

## Also: `bun run lint` was red on `main`

Four blocking biome errors, independent of the above and present before this branch:

- `app/docs/layout.tsx` — imports not sorted
- `app/lab/header/header-lab.tsx`, `components/docs/docs-shell.tsx` — formatter would reprint
- `app/lab/header/header-lab.tsx` — a `<label>` wrapping a Radix `Switch`; the switch renders a button, so nothing was ever associated. It now carries an `id` the label points at.

Six warnings are left alone — they do not fail the job, and the four `noDescendingSpecificity` ones in `globals.css` / `typeset.css` need selector reordering that can move rendering. The unused `eyebrow` param in `SectionHeading` looks like a leftover from an earlier refactor and deserves its own decision.

The `audit` job is separately red at shadscan score 59 against a floor of 60; not touched here.

## Note

`pull_request` runs use the workflow from the merge commit, so #277 needs its branch re-synced with `main` (or the checks re-run) after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEsQxsFaDGKvXVhmaVAjgk